### PR TITLE
Retry Search API failures

### DIFF
--- a/mdf_connect_server/config/default.py
+++ b/mdf_connect_server/config/default.py
@@ -25,6 +25,7 @@ DEFAULT = {
                             " inconvenience."),
 
     "SEARCH_BATCH_SIZE": 100,
+    "SEARCH_RETRIES": 3,
 
     "PUBLISH_COLLECTIONS": {
         "21": {


### PR DESCRIPTION
Make Connect ingest to Globus Search somewhat more robust against temporary Search errors, including 500s.