### PR TITLE
Xtract migration prep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
 - conda update -q conda
 - conda create -q -n test-env python=$TRAVIS_PYTHON_VERSION
 - source activate test-env
+- conda install hyperspy -c conda-forge
 - conda install -c pycalphad -c msys2 -c conda-forge pycalphad
 - pip install --upgrade pip
 - pip install -e .

--- a/mdf_connect_server/__init__.py
+++ b/mdf_connect_server/__init__.py
@@ -26,9 +26,6 @@ CONFIG["GLOBUS_CREDS"] = {
     "client_secret": CONFIG["API_CLIENT_SECRET"]
 }
 
-# from mdf_connect_server.utils import utils  # noqa: E402,F401
-# NOTE: flake8 complains about import not at top and import unused; this is fine
-
 # Make required dirs
 os.makedirs(CONFIG["LOCAL_PATH"], exist_ok=True)
 os.makedirs(CONFIG["FEEDSTOCK_PATH"], exist_ok=True)

--- a/mdf_connect_server/api/api.py
+++ b/mdf_connect_server/api/api.py
@@ -54,6 +54,7 @@ def disable_connect():
 @app.route('/', methods=["GET", "POST"])
 @app.route('/submit', methods=["GET"])
 @app.route('/convert', methods=["GET"])
+@app.route('/extract', methods=["GET"])
 @app.route('/ingest', methods=["GET"])
 def root_call():
     return redirect(CONFIG["FORM_URL"], code=302)
@@ -61,12 +62,13 @@ def root_call():
 
 @app.route('/submit', methods=["POST"])
 @app.route('/convert', methods=["POST"])
+@app.route('/extract', methods=["POST"])
 def accept_submission():
-    """Accept the JSON metadata and begin the conversion process."""
+    """Accept the JSON metadata and begin the extraction process."""
     logger.debug("Started new submission")
     access_token = request.headers.get("Authorization")
     try:
-        auth_res = utils.authenticate_token(access_token, "convert")
+        auth_res = utils.authenticate_token(access_token, "extract")
     except Exception as e:
         logger.error("Authentication failure: {}".format(e))
         return (jsonify({
@@ -177,8 +179,8 @@ def accept_submission():
         "dataset_acl": metadata.pop("dataset_acl", []),
         "index": metadata.pop("index", {}),
         "services": metadata.pop("services", {}),
-        "conversion_config": metadata.pop("conversion_config", {}),
-        "no_convert": metadata.pop("no_convert", False),  # Pass-through flag
+        "extraction_config": metadata.pop("extraction_config", {}),
+        "no_extract": metadata.pop("no_extract", False),  # Pass-through flag
         "submitter": name
     }
 
@@ -355,13 +357,13 @@ def accept_submission():
                 "test": CONFIG["DEFAULT_MRR_TEST"]
             }
 
-    # Must be Publishing if not converting
-    if sub_conf["no_convert"] and not sub_conf["services"].get("mdf_publish"):
+    # Must be Publishing if not extracting
+    if sub_conf["no_extract"] and not sub_conf["services"].get("mdf_publish"):
         return (jsonify({
             "success": False,
-            "error": "You must specify 'services.mdf_publish' if using the 'no_convert' flag",
+            "error": "You must specify 'services.mdf_publish' if using the 'no_extract' flag",
             "details": ("Datasets that are marked for 'pass-through' functionality "
-                        "(with the 'no_convert' flag) MUST be published (by using "
+                        "(with the 'no_extract' flag) MUST be published (by using "
                         "the 'mdf_publish' service in the 'services' block.")
         }), 400)
     # If Publishing, canonical data location is Publish location
@@ -437,7 +439,7 @@ def accept_submission():
             "error": repr(e)
             }), 500)
 
-    logger.info("Convert submission '{}' accepted".format(source_id))
+    logger.info("Extract submission '{}' accepted".format(source_id))
     return (jsonify({
         "success": True,
         "source_id": source_id
@@ -458,7 +460,7 @@ def get_status(source_id):
     """Fetch and return status information"""
     # User auth
     try:
-        auth_res = utils.authenticate_token(request.headers.get("Authorization"), "convert")
+        auth_res = utils.authenticate_token(request.headers.get("Authorization"), "extract")
     except Exception as e:
         logger.error("Authentication failure: {}".format(e))
         return (jsonify({
@@ -503,7 +505,7 @@ def get_user_submissions(user_id=None):
     """Get all submission statuses by a user."""
     # User auth
     try:
-        auth_res = utils.authenticate_token(request.headers.get("Authorization"), "convert")
+        auth_res = utils.authenticate_token(request.headers.get("Authorization"), "extract")
     except Exception as e:
         logger.error("Authentication failure: {}".format(e))
         return (jsonify({
@@ -550,7 +552,7 @@ def get_curator_tasks(user_id=None):
     access_token = request.headers.get("Authorization").replace("Bearer ", "")
     # User auth
     try:
-        auth_res = utils.authenticate_token(access_token, "convert")
+        auth_res = utils.authenticate_token(access_token, "extract")
     except Exception as e:
         logger.error("Authentication failure: {}".format(e))
         return (jsonify({
@@ -646,7 +648,7 @@ def curate_task(source_id):
     # User auth
     access_token = request.headers.get("Authorization").replace("Bearer ", "")
     try:
-        auth_res = utils.authenticate_token(access_token, "convert")
+        auth_res = utils.authenticate_token(access_token, "extract")
     except Exception as e:
         logger.error("Authentication failure: {}".format(e))
         return (jsonify({
@@ -738,7 +740,7 @@ def curate_task(source_id):
                 formatted_action = action[0].upper() + action[1:] + "ed"
                 curation_message = "{} by {}: {}".format(formatted_action, name, command["reason"])
                 submission_args = {
-                    "metadata": {},  # Not used after convert step
+                    "metadata": {},  # Not used after extract step
                     "sub_conf": {
                         # Only field needed to skip to curation resume
                         # Previous sub_conf loaded after resume

--- a/mdf_connect_server/api/api.py
+++ b/mdf_connect_server/api/api.py
@@ -237,6 +237,23 @@ def accept_submission():
     metadata["mdf"]["source_name"] = source_name
     metadata["mdf"]["version"] = source_id_info["search_version"]
 
+    # Fetch custom block descriptors, cast values to str, turn _description => _desc
+    new_custom = {}
+    for key, val in metadata.pop("custom", {}).items():
+        if key.endswith("_description"):
+            new_custom[key[:-len("ription")]] = str(val)
+        else:
+            new_custom[key] = str(val)
+    for key, val in metadata.pop("custom_desc", {}).items():
+        if key.endswith("_desc"):
+            new_custom[key] = str(val)
+        elif key.endswith("_description"):
+            new_custom[key[:-len("ription")]] = str(val)
+        else:
+            new_custom[key+"_desc"] = str(val)
+    if new_custom:
+        metadata["custom"] = new_custom
+
     # Get organization rules to apply
     if metadata["mdf"].get("organizations"):
         try:

--- a/mdf_connect_server/config/default.py
+++ b/mdf_connect_server/config/default.py
@@ -14,7 +14,7 @@ DEFAULT = {
     "PROCESSOR_WAIT_TIME": 20,  # Seconds
     "PROCESSOR_SLEEP_TIME": 40,  # Seconds
 
-    "NUM_TRANSFORMERS": 10,
+    "NUM_EXTRACTORS": 10,
     "NUM_SUBMITTERS": 5,
     "EXTRACTOR_ERROR_FILE": "extractor_errors.log",
 

--- a/mdf_connect_server/config/default.py
+++ b/mdf_connect_server/config/default.py
@@ -51,9 +51,11 @@ DEFAULT = {
 
     # Regexes for detecting Globus Web App links
     "GLOBUS_LINK_FORMS": [
-        "^https:\/\/www\.globus\.org\/app\/transfer",   # noqa: W605 (invalid escape char '\/')
-        "^https:\/\/app\.globus\.org\/file-manager",    # noqa: W605
-        "^https:\/\/app\.globus\.org\/transfer"         # noqa: W605
+        "^https:\/\/www\.globus\.org\/app\/transfer",  # noqa: W605 (invalid escape char '\/')
+        "^https:\/\/app\.globus\.org\/file-manager",  # noqa: W605
+        "^https:\/\/app\.globus\.org\/transfer",  # noqa: W605
+        "^https:\/\/.*globus.*(?=.*origin_id)(?=.*origin_path)",  # noqa: W605
+        "^https:\/\/.*globus.*(?=.*destination_id)(?=.*destination_path)"  # noqa: W605
     ],
 
     "GDRIVE_ROOT": "/Shared With Me",

--- a/mdf_connect_server/config/default.py
+++ b/mdf_connect_server/config/default.py
@@ -49,6 +49,13 @@ DEFAULT = {
     "API_SCOPE_ID": "mdf_dataset_submission",
     "TRANSFER_SCOPE": "urn:globus:auth:scope:transfer.api.globus.org:all",
 
+    # Regexes for detecting Globus Web App links
+    "GLOBUS_LINK_FORMS": [
+        "^https:\/\/www\.globus\.org\/app\/transfer",   # noqa: W605 (invalid escape char '\/')
+        "^https:\/\/app\.globus\.org\/file-manager",    # noqa: W605
+        "^https:\/\/app\.globus\.org\/transfer"         # noqa: W605
+    ],
+
     "GDRIVE_ROOT": "/Shared With Me",
 
     "ADMIN_GROUP_ID": "5fc63928-3752-11e8-9c6f-0e00fd09bf20",

--- a/mdf_connect_server/config/default.py
+++ b/mdf_connect_server/config/default.py
@@ -16,7 +16,7 @@ DEFAULT = {
 
     "NUM_TRANSFORMERS": 10,
     "NUM_SUBMITTERS": 5,
-    "TRANSFORMER_ERROR_FILE": "parser_errors.log",
+    "EXTRACTOR_ERROR_FILE": "extractor_errors.log",
 
     "CANCEL_WAIT_TIME": 60,  # Seconds
 
@@ -61,7 +61,7 @@ DEFAULT = {
     "GDRIVE_ROOT": "/Shared With Me",
 
     "ADMIN_GROUP_ID": "5fc63928-3752-11e8-9c6f-0e00fd09bf20",
-    "CONVERT_GROUP_ID": "cc192dca-3751-11e8-90c1-0a7c735d220a"
+    "EXTRACT_GROUP_ID": "cc192dca-3751-11e8-90c1-0a7c735d220a"
 }
 with open(os.path.join(DEFAULT["SCHEMA_PATH"], "mrr_template.xml")) as f:
     DEFAULT["MRR_TEMPLATE"] = f.read()

--- a/mdf_connect_server/config/groupings.py
+++ b/mdf_connect_server/config/groupings.py
@@ -4,7 +4,7 @@ GROUPINGS = {
             "files": [
                 ".cif",
             ],
-            "parsers": [
+            "extractors": [
                 "crystal_structure",
                 "pif"
             ],
@@ -31,7 +31,7 @@ GROUPINGS = {
                 "vasp_run.xml",
                 "xdatcar"
             ],
-            "parsers": [
+            "extractors": [
                 "pif",
                 "crystal_structure"
             ],
@@ -45,7 +45,7 @@ GROUPINGS = {
             "files": [
                 ".json"
             ],
-            "parsers": [
+            "extractors": [
                 "json"
             ],
             "params": {}
@@ -54,7 +54,7 @@ GROUPINGS = {
             "files": [
                 ".csv"
             ],
-            "parsers": [
+            "extractors": [
                 "csv",
                 "pif"
             ],

--- a/mdf_connect_server/processor/__init__.py
+++ b/mdf_connect_server/processor/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 # NOTE: flake8 complains about these imports going unused; this is fine
-from .transformer import transform
+from .extractors import run_extractors
 from .validator import Validator
-from .converter import convert
+from .start_extractors import start_extractors
 from .processor import processor

--- a/mdf_connect_server/processor/converter.py
+++ b/mdf_connect_server/processor/converter.py
@@ -7,7 +7,7 @@ from queue import Empty
 
 import mdf_toolbox
 
-from mdf_connect_server import CONFIG, utils
+from mdf_connect_server import CONFIG
 from mdf_connect_server.processor import transform, Validator
 
 
@@ -37,7 +37,6 @@ def convert(root_path, convert_params):
         extensions (list of str): If success is True, all unique file extensions in the dataset.
     """
     source_id = convert_params.get("dataset", {}).get("mdf", {}).get("source_id", "unknown")
-    source_info = utils.split_source_id(source_id)
     vald = Validator(schema_path=CONFIG["SCHEMA_PATH"])
 
     # Process dataset entry (to fail validation early if dataset entry is invalid)
@@ -64,8 +63,7 @@ def convert(root_path, convert_params):
     '''
 
     # Validate dataset
-    ds_res = vald.start_dataset(full_dataset, source_info,
-                                convert_params.get("validation_info", None))
+    ds_res = vald.start_dataset(full_dataset, convert_params.get("validation_info", None))
     if not ds_res["success"]:
         return ds_res
 

--- a/mdf_connect_server/processor/converter.py
+++ b/mdf_connect_server/processor/converter.py
@@ -42,6 +42,7 @@ def convert(root_path, convert_params):
 
     # Process dataset entry (to fail validation early if dataset entry is invalid)
     full_dataset = convert_params["dataset"]
+    '''
     # Fetch custom block descriptors, cast values to str
     new_custom = {}
     # custom block descriptors
@@ -60,6 +61,7 @@ def convert(root_path, convert_params):
             new_custom[key+"_desc"] = str(val)
     if new_custom:
         full_dataset["custom"] = new_custom
+    '''
 
     # Validate dataset
     ds_res = vald.start_dataset(full_dataset, source_info,

--- a/mdf_connect_server/processor/converter.py
+++ b/mdf_connect_server/processor/converter.py
@@ -104,6 +104,7 @@ def convert(root_path, convert_params):
                 logger.info("{}: Record error - terminating transformers".format(source_id))
                 # TODO: Use t.kill() (Py3.7-only)
                 [t.terminate() for t in transformers]
+                # [t.kill() for t in transformers]
                 [t.join() for t in transformers]
                 logger.debug("{}: Transformers terminated".format(source_id))
 

--- a/mdf_connect_server/processor/extractors.py
+++ b/mdf_connect_server/processor/extractors.py
@@ -664,7 +664,7 @@ def _extract_file_info(group, params=None):
     list of dict: The record(s) extractd.
     """
     try:
-        globus_host_info = urllib.extract.urlextract(params["extractors"]["file"]["globus_host"])
+        globus_host_info = urllib.parse.urlparse(params["extractors"]["file"]["globus_host"])
         host_endpoint = globus_host_info.netloc
         host_path = globus_host_info.path
     except Exception as e:

--- a/mdf_connect_server/processor/processor.py
+++ b/mdf_connect_server/processor/processor.py
@@ -222,7 +222,7 @@ def submission_driver(metadata, sub_conf, source_id, access_token, user_id):
                 return
 
             utils.update_status(source_id, "data_download", "M",
-                                text=("{} files will be extracted ({} archives extracted)"
+                                text=("{} files will be grouped and extracted (from {} archives)"
                                       .format(num_files, dl_res["num_extracted"])),
                                 except_on_fail=True)
             canon_data_sources = ["globus://{}{}".format(CONFIG["LOCAL_EP"], local_path)]

--- a/mdf_connect_server/processor/processor.py
+++ b/mdf_connect_server/processor/processor.py
@@ -304,7 +304,7 @@ def submission_driver(metadata, sub_conf, source_id, access_token, user_id):
             # If nothing in dataset, panic
             if not dataset:
                 utils.update_status(source_id, "converting", "F",
-                                    text="Could not parse dataset entry", except_on_fail=True)
+                                    text="Could not process dataset entry", except_on_fail=True)
                 utils.complete_submission(source_id)
                 return
             # If not converting, show status as skipped
@@ -314,14 +314,9 @@ def submission_driver(metadata, sub_conf, source_id, access_token, user_id):
                     logger.error("{}: Records parsed with no_convert flag ({} records)"
                                  .format(source_id, num_records))
                 utils.update_status(source_id, "converting", "N", except_on_fail=True)
-            # If no records, warn user
-            elif num_records < 1:
-                utils.update_status(source_id, "converting", "U",
-                                    text=("No records were parsed out of {} groups"
-                                          .format(num_groups)), except_on_fail=True)
             else:
                 utils.update_status(source_id, "converting", "M",
-                                    text=("{} records parsed out of {} groups"
+                                    text=("{} metadata records extracted out of {} file groups"
                                           .format(num_records, num_groups)), except_on_fail=True)
             logger.debug("{}: {} entries parsed".format(source_id, num_records+1))
 

--- a/mdf_connect_server/processor/validator.py
+++ b/mdf_connect_server/processor/validator.py
@@ -316,7 +316,7 @@ class Validator:
             list_of_elem.sort()
             # Currently deprecated
             # If any "element" isn't in the periodic table,
-            # the composition is likely not a chemical formula and should not be parsed
+            # the composition is likely not a chemical formula and should not be processed
 #                if all([elem in DICT_OF_ALL_ELEMENTS.values() for elem in list_of_elem]):
 #                    record["elements"] = list_of_elem
 

--- a/mdf_connect_server/processor/validator.py
+++ b/mdf_connect_server/processor/validator.py
@@ -42,7 +42,6 @@ class Validator:
     """
     def __init__(self, schema_path):
         self.__dataset = None  # Serves as initialized flag
-        self.__source_info = None
         self.__tempfile = None
         self.__scroll_id = None
         self.__ingest_date = datetime.utcnow().isoformat("T") + "Z"
@@ -50,12 +49,11 @@ class Validator:
         self.__finished = None  # Flag - has user called get_finished_dataset() for this dataset?
         self.__schema_dir = schema_path
 
-    def start_dataset(self, ds_md, source_info=None, validation_info=None):
+    def start_dataset(self, ds_md, validation_info=None):
         """Validate a dataset against the MDF schema.
 
         Arguments:
         ds_md (dict): The dataset metadata to validate.
-        source_info (dict): source_id information.
         validation_info (dict): Additional validation configuration.
 
         Returns:
@@ -70,7 +68,6 @@ class Validator:
                 "error": "Dataset validation already in progress."
                 }
         self.__finished = False
-        self.__source_info = source_info or {}
 
         if validation_info is None:
             validation_info = {}
@@ -108,13 +105,8 @@ class Validator:
         # resource_type
         ds_md["mdf"]["resource_type"] = "dataset"
 
-        # source_name
-        if not ds_md["mdf"].get("source_name"):
-            ds_md["mdf"]["source_name"] = self.__source_info.get("source_name")
-
-        # source_id
-        if not ds_md["mdf"].get("source_id"):
-            ds_md["mdf"]["source_id"] = self.__source_info.get("source_id")
+        # mdf-block fields source_id and source_name must already be set
+        # (should be the case in correct preprocessing of submission)
 
         # acl
         if not ds_md["mdf"].get("acl"):

--- a/mdf_connect_server/utils/__init__.py
+++ b/mdf_connect_server/utils/__init__.py
@@ -3,4 +3,6 @@
 #       Also the * import, which is the least painful way to have all those imports
 from .search_ingester import (search_ingest, submit_ingests,
                               update_search_entries, update_search_subjects)
+# TODO (XTH): Clean up utils imports
 from .utils import *
+import .api_utils

--- a/mdf_connect_server/utils/__init__.py
+++ b/mdf_connect_server/utils/__init__.py
@@ -5,4 +5,4 @@ from .search_ingester import (search_ingest, submit_ingests,
                               update_search_entries, update_search_subjects)
 # TODO (XTH): Clean up utils imports
 from .utils import *
-import .api_utils
+from .api_utils import *

--- a/mdf_connect_server/utils/api_utils.py
+++ b/mdf_connect_server/utils/api_utils.py
@@ -210,7 +210,7 @@ def authenticate_token(token, groups, require_all=False):
     }
 
 
-def cancel_submission(source_id, wait=True):
+def api_cancel_submission(source_id, wait=True):
     """Cancel an in-progress submission.
     Will not cancel completed or already-cancelled submissions.
 
@@ -231,7 +231,7 @@ def cancel_submission(source_id, wait=True):
     raise NotImplementedError
 
 
-def complete_submission(source_id, cleanup=CONFIG["DEFAULT_CLEANUP"]):
+def api_complete_submission(source_id, cleanup=CONFIG["DEFAULT_CLEANUP"]):
     # TODO (XTH): Modify for API-only
     raise NotImplementedError
     """Complete a submission.

--- a/mdf_connect_server/utils/api_utils.py
+++ b/mdf_connect_server/utils/api_utils.py
@@ -1,0 +1,989 @@
+from copy import deepcopy
+import json
+import logging
+import os
+import re
+import urllib
+
+import boto3
+from boto3.dynamodb.conditions import Attr
+import globus_sdk
+import jsonschema
+import mdf_toolbox
+
+from mdf_connect_server import CONFIG
+# TODO (XTH): Remove old imports (will be deprecated, also causes F401)
+from mdf_connect_server.utils import (create_status, submit_to_queue,  # noqa: F401
+                                      translate_status, update_status, validate_status)
+
+
+logger = logging.getLogger(__name__)
+
+# DynamoDB setup
+DMO_CLIENT = boto3.resource('dynamodb',
+                            aws_access_key_id=CONFIG["AWS_KEY"],
+                            aws_secret_access_key=CONFIG["AWS_SECRET"],
+                            region_name="us-east-1")
+DMO_TABLES = {
+    # TODO (XTH): Sub log table, delete status and curation tables
+    # "sub_log": CONFIG["SUB_LOG_TABLE"]
+    "status": CONFIG["DYNAMO_STATUS_TABLE"],
+    "curation": CONFIG["DYNAMO_CURATION_TABLE"]
+}
+DMO_SCHEMA = {
+    # "TableName": DMO_TABLE,
+    "AttributeDefinitions": [{
+        "AttributeName": "source_id",
+        "AttributeType": "S"
+    }],
+    "KeySchema": [{
+        "AttributeName": "source_id",
+        "KeyType": "HASH"
+    }],
+    "ProvisionedThroughput": {
+        "ReadCapacityUnits": 20,
+        "WriteCapacityUnits": 20
+    }
+}
+
+
+def authenticate_token(token, groups, require_all=False):
+    """Authenticate a token.
+    Arguments:
+        token (str): The token to authenticate with.
+        groups (str or list of str): The Globus Group UUIDs to require the user belong to.
+                The special value "public" is also allowed to always pass this check.
+        require_all (bool): When True, the user must be in all groups to succeed the
+                group check.
+                When False, the user must be in at least one group to succeed.
+                Default False.
+
+    Returns:
+        dict: Token and user info.
+    """
+    if not token:
+        return {
+            "success": False,
+            "error": "Not Authenticated",
+            "error_code": 401
+        }
+    try:
+        token = token.replace("Bearer ", "")
+        auth_client = globus_sdk.ConfidentialAppAuthClient(CONFIG["API_CLIENT_ID"],
+                                                           CONFIG["API_CLIENT_SECRET"])
+        auth_res = auth_client.oauth2_token_introspect(token, include="identities_set")
+    except Exception as e:
+        logger.error("Error authenticating token: {}".format(repr(e)))
+        return {
+            "success": False,
+            "error": "Authentication could not be completed",
+            "error_code": 500
+        }
+    if not auth_res:
+        return {
+            "success": False,
+            "error": "Token could not be validated",
+            "error_code": 401
+        }
+    # Check that token is active
+    if not auth_res["active"]:
+        return {
+            "success": False,
+            "error": "Token expired",
+            "error_code": 403
+        }
+    # Check correct scope and audience
+    if (CONFIG["API_SCOPE"] not in auth_res["scope"]
+            or CONFIG["API_SCOPE_ID"] not in auth_res["aud"]):
+        return {
+            "success": False,
+            "error": "Not authorized to MDF Connect scope",
+            "error_code": 401
+        }
+    # Finally, verify user is in appropriate group(s)
+    if isinstance(groups, str):
+        groups = [groups]
+
+    # Groups setup
+    groups_auth = deepcopy(CONFIG["GLOBUS_CREDS"])
+    groups_auth["services"] = ["groups"]
+    try:
+        nexus = mdf_toolbox.confidential_login(**groups_auth)["groups"]
+    except Exception as e:
+        logger.error("NexusClient creation error: {}".format(repr(e)))
+        return {
+            "success": False,
+            "error": "Unable to connect to Globus Groups",
+            "error_code": 500
+        }
+
+    # Globus Groups does not take UUIDs, only usernames, but Globus Auth uses UUIDs
+    # for identity-aware applications. Therefore, for Connect to be identity-aware,
+    # we must convert the UUIDs into usernames.
+    # However, the GlobusID "username" is not the email-like address, just the prefix.
+    user_usernames = set([iden["username"].replace("@globusid.org", "")
+                          for iden in auth_client.get_identities(
+                                                    ids=auth_res["identities_set"])["identities"]])
+    auth_succeeded = False
+    missing_groups = []  # Used for require_all compliance
+    group_roles = []
+    for grp in groups:
+        # public always succeeds
+        if grp.lower() == "public":
+            group_roles.append("member")
+            auth_succeeded = True
+        else:
+            # Translate convert and admin groups
+            if grp.lower() == "convert":
+                grp = CONFIG["CONVERT_GROUP_ID"]
+            elif grp.lower() == "admin":
+                grp = CONFIG["ADMIN_GROUP_ID"]
+            # Group membership checks - each identity with each group
+            for user_identifier in user_usernames:
+                try:
+                    member_info = nexus.get_group_membership(grp, user_identifier)
+                    assert member_info["status"] == "active"
+                    group_roles.append(member_info["role"])
+                # Not in group or not active
+                except (globus_sdk.GlobusAPIError, AssertionError):
+                    # Log failed groups
+                    missing_groups.append(grp)
+                # Error getting membership
+                except Exception as e:
+                    logger.error("NexusClient fetch error: {}".format(repr(e)))
+                    return {
+                        "success": False,
+                        "error": "Unable to connect to Globus Groups",
+                        "error_code": 500
+                    }
+                else:
+                    auth_succeeded = True
+    # If must be in all groups, fail out if any groups missing
+    if require_all and missing_groups:
+        logger.debug("Auth rejected: require_all set, user '{}' not in '{}'"
+                     .format(user_usernames, missing_groups))
+        return {
+            "success": False,
+            "error": "You cannot access this service or organization",
+            "error_code": 403
+        }
+    if not auth_succeeded:
+        logger.debug("Auth rejected: User '{}' not in any group: '{}'"
+                     .format(user_usernames, groups))
+        return {
+            "success": False,
+            "error": "You cannot access this service or organization",
+            "error_code": 403
+        }
+
+    # Admin membership check (allowed to fail)
+    is_admin = False
+    for user_identifier in user_usernames:
+        try:
+            admin_info = nexus.get_group_membership(CONFIG["ADMIN_GROUP_ID"], user_identifier)
+            assert admin_info["status"] == "active"
+        # Username is not active admin, which is fine
+        except (globus_sdk.GlobusAPIError, AssertionError):
+            pass
+        # Error getting membership
+        except Exception as e:
+            logger.error("NexusClient admin fetch error: {}".format(repr(e)))
+            return {
+                "success": False,
+                "error": "Unable to connect to Globus Groups",
+                "error_code": 500
+            }
+        # Successful check, is admin
+        else:
+            is_admin = True
+
+    return {
+        "success": True,
+        "token_info": auth_res,
+        "user_id": auth_res["sub"],
+        "username": user_identifier,
+        "name": auth_res["name"] or "Not given",
+        "email": auth_res["email"] or "Not given",
+        "identities_set": auth_res["identities_set"],
+        "group_roles": group_roles,
+        "is_admin": is_admin
+    }
+
+
+def cancel_submission(source_id, wait=True):
+    """Cancel an in-progress submission.
+    Will not cancel completed or already-cancelled submissions.
+
+    Arguments:
+    source_id (str): The source_id of the submission.
+    wait (bool): If True, will wait on submission completion before returning success.
+                 If False, will not wait.
+                 Default True.
+    Returns:
+    success (bool): True if the submission was successfully cancelled, False otherwise.
+    stopped (bool): True if the submission is no longer operating. False otherwise.
+                    The difference between success and stopped is that a submission
+                    that completed previously was not successfully cancelled, but was stopped.
+                    Can be False when success is True if wait is True.
+    error (str): The error message. Only exists if success is False.
+    """
+    # TODO (XTH)
+    raise NotImplementedError
+
+
+def complete_submission(source_id, cleanup=CONFIG["DEFAULT_CLEANUP"]):
+    # TODO (XTH): Modify for API-only
+    raise NotImplementedError
+    """Complete a submission.
+
+    Arguments:
+    source_id (str): The source_id of the submission.
+    cleanup (bool): If True, will delete the local submission data.
+                    If False, will not.
+                    Default True.
+
+    Returns:
+    success (bool): True on success, False otherwise.
+    error (str): The error message. Only exists if success is False.
+    """
+    """
+    # Check that status active is True
+    if not read_table("status", source_id).get("status", {}).get("active", False):
+        return {
+            "success": False,
+            "error": "Submission not in progress"
+        }
+    logger.debug("{}: Starting cleanup".format(source_id))
+    # Remove dirs containing processed data, if requested
+    if cleanup:
+        cleanup_paths = [
+            os.path.join(CONFIG["LOCAL_PATH"], source_id) + "/",
+            os.path.join(CONFIG["SERVICE_DATA"], source_id) + "/",
+            os.path.join(CONFIG["CURATION_DATA"], source_id) + ".json"
+        ]
+        for cleanup in cleanup_paths:
+            if os.path.exists(cleanup):
+                try:
+                    # NOTE: local_admin_delete not in api_utils
+                    clean_res = None  # local_admin_delete(cleanup)
+                    if not clean_res["success"]:
+                        raise IOError(clean_res["error"])
+                    elif not clean_res["deleted"]:
+                        logger.warning("{}: Cleanup path '{}' did not exist".format(source_id,
+                                                                                    cleanup))
+                except Exception as e:
+                    logger.error("{}: Could not remove path '{}': {}".format(source_id,
+                                                                             cleanup, e))
+                    return {
+                        "success": False,
+                        "error": "Unable to clear processed data"
+                    }
+            else:
+                logger.debug("{}: Cleanup path does not exist: {}".format(source_id, cleanup))
+        logger.debug("{}: File cleanup finished".format(source_id))
+    # Delete curation entry if exists
+    delete_from_table("curation", source_id)
+    # Update status to inactive
+    update_res = modify_status_entry(source_id, {"active": False})
+    if not update_res["success"]:
+        return update_res
+
+    logger.debug("{}: Cleanup finished".format(source_id))
+    return {
+        "success": True
+    }
+    """
+
+
+def create_sub_log(sub_log):
+    """Create a submission log entry in the submission database."""
+    # TODO (XTH)
+    raise NotImplementedError
+
+
+def delete_from_table(table_name, source_id):
+    tbl_res = get_dmo_table(table_name)
+    if not tbl_res["success"]:
+        return tbl_res
+    table = tbl_res["table"]
+
+    # Check that entry exists
+    if not read_table(table_name, source_id)["success"]:
+        return {
+            "success": False,
+            "error": "ID {} does not exist in database".format(source_id)
+        }
+    try:
+        table.delete_item(Key={"source_id": source_id})
+    except Exception as e:
+        return {
+            "success": False,
+            "error": repr(e)
+        }
+
+    # Verify entry deleted
+    if read_table(table_name, source_id)["success"]:
+        return {
+            "success": False,
+            "error": "Entry not deleted from database"
+        }
+
+    return {
+        "success": True
+    }
+
+
+def fetch_org_rules(org_names, user_rules=None):
+    """Fetch organization rules and metadata.
+
+    Arguments:
+        org_names (str or list of str): Org name or alias to fetch rules for.
+        user_rules (dict): User-supplied rules to add, if desired. Default None.
+
+    Returns:
+        tuple: (list: All org canonical_names, dict: All appropriate rules)
+    """
+    # Normalize name: Remove special characters (including whitespace) and capitalization
+    # Function for convenience, but not generalizable/useful for other cases
+    def normalize_name(name): return "".join([c for c in name.lower() if c.isalnum()])
+
+    # Fetch list of organizations
+    with open(os.path.join(CONFIG["AUX_DATA_PATH"], "organizations.json")) as f:
+        organizations = json.load(f)
+
+    # Cache list of all organization aliases to match against
+    # Transform into tuple (normalized_aliases, org_rules) for convenience
+    all_clean_orgs = []
+    for org in organizations:
+        aliases = [normalize_name(alias) for alias in (org.get("aliases", [])
+                                                       + [org["canonical_name"]])]
+        all_clean_orgs.append((aliases, org))
+
+    if isinstance(org_names, list):
+        orgs_to_fetch = org_names
+    else:
+        orgs_to_fetch = [org_names]
+    rules = {}
+    all_names = []
+    # Fetch org rules and parent rules
+    while len(orgs_to_fetch) > 0:
+        # Process sub 0 always, so orgs processed in order
+        # New org matches on canonical_name or any alias
+        fetch_org = orgs_to_fetch.pop(0)
+        new_org_data = [org for aliases, org in all_clean_orgs
+                        if normalize_name(fetch_org) in aliases]
+        if len(new_org_data) < 1:
+            raise ValueError("Organization '{}' not registered in MDF Connect (from '{}')"
+                             .format(fetch_org, org_names))
+        elif len(new_org_data) > 1:
+            raise ValueError("Multiple organizations found with name '{}' (from '{}')"
+                             .format(fetch_org, org_names))
+        new_org_data = deepcopy(new_org_data[0])
+
+        # Check that org rules not already fetched
+        if new_org_data["canonical_name"] in all_names:
+            continue
+        else:
+            all_names.append(new_org_data["canonical_name"])
+
+        # Add all (unprocessed) parents to fetch list
+        orgs_to_fetch.extend([parent for parent in new_org_data.get("parent_organizations", [])
+                              if parent not in all_names])
+
+        # Merge new rules with old
+        # Strip out unneeded info
+        new_org_data.pop("canonical_name", None)
+        new_org_data.pop("aliases", None)
+        new_org_data.pop("description", None)
+        new_org_data.pop("homepage", None)
+        new_org_data.pop("parent_organizations", None)
+        # Save correct curation state
+        if rules.get("curation", False) or new_org_data.get("curation", False):
+            curation = True
+        else:
+            curation = False
+        # Merge new rules into old rules
+        rules = mdf_toolbox.dict_merge(rules, new_org_data, append_lists=True)
+        # Ensure curation set if needed
+        if curation:
+            rules["curation"] = curation
+
+    # Merge in user-set rules (with lower priority than any org-set rules)
+    if user_rules:
+        rules = mdf_toolbox.dict_merge(rules, user_rules)
+        # If user set curation, set curation
+        # Otherwise user preference is overridden by org preference
+        if user_rules.get("curation", False):
+            rules["curation"] = True
+
+    return (all_names, rules)
+
+
+def get_dmo_table(table_name, client=DMO_CLIENT):
+    try:
+        table_key = DMO_TABLES[table_name]
+    except KeyError:
+        return {
+            "success": False,
+            "error": "Invalid table '{}'".format(table_name)
+        }
+    try:
+        table = client.Table(table_key)
+        dmo_status = table.table_status
+        if dmo_status != "ACTIVE":
+            raise ValueError("Table not active")
+    except (ValueError, client.meta.client.exceptions.ResourceNotFoundException):
+        return {
+            "success": False,
+            "error": "Table does not exist or is not active"
+            }
+    except Exception as e:
+        return {
+            "success": False,
+            "error": repr(e)
+            }
+    else:
+        return {
+            "success": True,
+            "table": table
+            }
+
+
+def initialize_dmo_table(table_name, client=DMO_CLIENT):
+    try:
+        table_key = DMO_TABLES[table_name]
+    except KeyError:
+        return {
+            "success": False,
+            "error": "Invalid table '{}'".format(table_name)
+        }
+    schema = deepcopy(DMO_SCHEMA)
+    schema["TableName"] = table_key
+
+    tbl_res = get_dmo_table(table_name, client)
+    # Table should not be active already
+    if tbl_res["success"]:
+        return {
+            "success": False,
+            "error": "Table already created"
+            }
+    # If misc/other exception, cannot create table
+    elif tbl_res["error"] != "Table does not exist or is not active":
+        return tbl_res
+
+    try:
+        new_table = client.create_table(**schema)
+        new_table.wait_until_exists()
+    except client.meta.client.exceptions.ResourceInUseException:
+        return {
+            "success": False,
+            "error": "Table concurrently created"
+            }
+    except Exception as e:
+        return {
+            "success": False,
+            "error": repr(e)
+            }
+
+    tbl_res2 = get_dmo_table(table_name, client)
+    if not tbl_res2["success"]:
+        return {
+            "success": False,
+            "error": "Unable to create table: {}".format(tbl_res2["error"])
+            }
+    else:
+        return {
+            "success": True,
+            "table": tbl_res2["table"]
+            }
+
+
+def make_globus_app_link(globus_uri):
+    globus_uri_info = urllib.parse.urlparse(normalize_globus_uri(globus_uri))
+    globus_link = CONFIG["TRANSFER_WEB_APP_LINK"] \
+        .format(globus_uri_info.netloc, urllib.parse.quote(globus_uri_info.path))
+    return globus_link
+
+
+def make_source_id(title, author, test=False, index=None, sanitize_only=False):
+    """Make a source name out of a title."""
+    if index is None:
+        index = (CONFIG["INGEST_TEST_INDEX"] if test else CONFIG["INGEST_INDEX"])
+    # Stopwords to delete from the source_name
+    # Not using NTLK to avoid an entire package dependency for one minor feature,
+    # and the NLTK stopwords are unlikely to be in a dataset title ("your", "that'll", etc.)
+    delete_words = [
+        "a",
+        "an",
+        "and",
+        "as",
+        "data",
+        "dataset",
+        "for",
+        "from",
+        "in",
+        "of",
+        "or",
+        "study",
+        "test",  # Clears test flag from new source_id
+        "that",
+        "the",
+        "this",
+        "to",
+        "very",
+        "with"
+    ]
+    # Remove any existing version number from title
+    title = split_source_id(title)["source_name"]
+
+    # Tokenize title and author
+    # Valid token separators are space and underscore
+    # Discard empty tokens
+    title_tokens = [t for t in title.strip().replace("_", " ").split() if t]
+    author_tokens = [t for t in author.strip().replace("_", " ").split() if t]
+
+    # Clean title tokens
+    title_clean = []
+    for token in title_tokens:
+        # Clean token is lowercase and alphanumeric
+        # TODO: After Py3.7 upgrade, use .isascii()
+        clean_token = "".join([char for char in token.lower() if char.isalnum()])
+        # and char.isascii()])
+        if clean_token and clean_token not in delete_words:
+            title_clean.append(clean_token)
+
+    # Clean author tokens, merge into one word
+    author_word = ""
+    for token in author_tokens:
+        clean_token = "".join([char for char in token.lower() if char.isalnum()])
+        # and char.isascii()])
+        author_word += clean_token
+
+    # Remove author_word from title, if exists (e.g. from previous make_source_id())
+    while author_word in title_clean and not sanitize_only:
+        title_clean.remove(author_word)
+
+    # Select words from title for source_name
+    # Use up to the first two words + last word
+    if len(title_clean) >= 1:
+        word1 = title_clean[0]
+    else:
+        # Must have at least one word
+        raise ValueError("Title '{}' invalid: Must have at least one word that is not "
+                         "the author name (the following words do not count: '{}')"
+                         .format(title, delete_words))
+    if len(title_clean) >= 2:
+        word2 = title_clean[1]
+    else:
+        word2 = ""
+    if len(title_clean) >= 3:
+        word3 = title_clean[-1]
+    else:
+        word3 = ""
+
+    # Assemble source_name
+    # Strip trailing underscores from missing words
+    if sanitize_only:
+        source_name = "_".join(title_clean).strip("_")
+    else:
+        source_name = "{}_{}_{}_{}".format(author_word, word1, word2, word3).strip("_")
+
+    # Add test flag if necessary
+    if test:
+        source_name = "_test_" + source_name
+
+    # Determine version number to add
+    # Get last Search version
+    search_creds = mdf_toolbox.dict_merge(CONFIG["GLOBUS_CREDS"], {"services": ["search"]})
+    search_client = mdf_toolbox.confidential_login(**search_creds)["search"]
+    old_q = {
+        "q": "mdf.source_name:{} AND mdf.resource_type:dataset".format(source_name),
+        "advanced": True,
+        "limit": 2,  # Should only ever be one, if two are returned there's a problem
+        "offset": 0
+    }
+    old_search = mdf_toolbox.gmeta_pop(search_client.post_search(
+                                            mdf_toolbox.translate_index(index), old_q))
+    if len(old_search) == 0:
+        search_version = 1
+    elif len(old_search) == 1:
+        search_version = old_search[0]["mdf"]["version"] + 1
+    else:
+        logger.error("{}: {} dataset entries found in Search: {}"
+                     .format(source_name, len(old_search), old_search))
+        raise ValueError("Dataset entry in Search has error")
+
+    # Get old submission information
+    scan_res = scan_table(table_name="status", fields=["source_id", "user_id"],
+                          filters=[("source_id", "^", source_name)])
+    if not scan_res["success"]:
+        logger.error("Unable to scan status database for '{}': '{}'"
+                     .format(source_name, scan_res["error"]))
+        raise ValueError("Dataset status has error")
+    user_ids = set([sub["user_id"] for sub in scan_res["results"]])
+    # Get most recent previous source_id and info
+    if scan_res["results"]:
+        old_source_id = max([sub["source_id"] for sub in scan_res["results"]])
+    else:
+        old_source_id = ""
+    old_source_info = split_source_id(old_source_id)
+    old_search_version = old_source_info["search_version"]
+    old_sub_version = old_source_info["submission_version"]
+    # If new Search version > old Search version, sub version should reset
+    if search_version > old_search_version:
+        sub_version = 1
+    # If they're the same, sub version should increment
+    elif search_version == old_search_version:
+        sub_version = old_sub_version + 1
+    # Old > new is an error
+    else:
+        logger.error("Old Search version '{}' > new '{}': {}"
+                     .format(old_search_version, search_version, source_name))
+        raise ValueError("Dataset entry in Search has error")
+
+    source_id = "{}_v{}.{}".format(source_name, search_version, sub_version)
+
+    return {
+        "source_id": source_id,
+        "source_name": source_name,
+        "search_version": search_version,
+        "submission_version": sub_version,
+        "user_id_list": user_ids
+    }
+
+
+def modify_sub_entry(source_id, modifications):
+    """Modify a submission log entry."""
+    # TODO: XTH
+    raise NotImplementedError
+
+
+def normalize_globus_uri(location):
+    """Normalize a Globus Web App link or Google Drive URI into a globus:// URI.
+    For Google Drive URIs, the file(s) must be shared with
+    materialsdatafacility@gmail.com.
+    If the URI is not a Globus Web App link or Google Drive URI,
+    it is returned unchanged.
+
+    Arguments:
+        location (str): One URI to normalize.
+
+    Returns:
+        str: The normalized URI, or the original URI if no normalization was possible.
+    """
+    loc_info = urllib.parse.urlparse(location)
+    # Globus Web App link into globus:// form
+    if any([re.search(pattern, location) for pattern in CONFIG["GLOBUS_LINK_FORMS"]]):
+        data_info = urllib.parse.unquote(loc_info.query)
+        # EP ID is in origin or dest
+        ep_start = data_info.find("origin_id=")
+        if ep_start < 0:
+            ep_start = data_info.find("destination_id=")
+            if ep_start < 0:
+                raise ValueError("Invalid Globus Transfer UI link")
+            else:
+                ep_start += len("destination_id=")
+        else:
+            ep_start += len("origin_id=")
+        ep_end = data_info.find("&", ep_start)
+        if ep_end < 0:
+            ep_end = len(data_info)
+        ep_id = data_info[ep_start:ep_end]
+
+        # Same for path
+        path_start = data_info.find("origin_path=")
+        if path_start < 0:
+            path_start = data_info.find("destination_path=")
+            if path_start < 0:
+                raise ValueError("Invalid Globus Transfer UI link")
+            else:
+                path_start += len("destination_path=")
+        else:
+            path_start += len("origin_path=")
+        path_end = data_info.find("&", path_start)
+        if path_end < 0:
+            path_end = len(data_info)
+        path = data_info[path_start:path_end]
+
+        # Make new location
+        new_location = "globus://{}{}".format(ep_id, path)
+
+    # Google Drive protocol into globus:// form
+    elif loc_info.scheme in ["gdrive", "google", "googledrive"]:
+        # Correct form is "google:///path/file.dat"
+        # (three slashes - two for scheme end, one for path start)
+        # But if a user uses two slashes, the netloc will incorrectly be the top dir
+        # (netloc="path", path="/file.dat")
+        # Otherwise netloc is nothing (which is correct)
+        if loc_info.netloc:
+            gpath = "/" + loc_info.netloc + loc_info.path
+        else:
+            gpath = loc_info.path
+        # Don't use os.path.join because gpath starts with /
+        # GDRIVE_ROOT does not end in / to make compatible
+        new_location = "globus://{}{}{}".format(CONFIG["GDRIVE_EP"], CONFIG["GDRIVE_ROOT"], gpath)
+
+    # Default - do nothing
+    else:
+        new_location = location
+
+    return new_location
+
+
+def read_table(table_name, source_id):
+    tbl_res = get_dmo_table(table_name)
+    if not tbl_res["success"]:
+        return tbl_res
+    table = tbl_res["table"]
+
+    entry = table.get_item(Key={"source_id": source_id}, ConsistentRead=True).get("Item")
+    if not entry:
+        return {
+            "success": False,
+            "error": "ID {} not found in {} database".format(source_id, table_name)
+            }
+    return {
+        "success": True,
+        "status": entry
+        }
+
+
+def scan_table(table_name, fields=None, filters=None):
+    """Scan the status or curation databases..
+
+    Arguments:
+    table_name (str): The Dynamo table to scan.
+    fields (list of str): The fields from the results to return.
+                          Default None, to return all fields.
+    filters (list of tuples): The filters to apply. Format: (field, operator, value)
+                              For an entry to be returned, all filters must match.
+                              Default None, to return all entries.
+                           field: The status field to filter on.
+                           operator: The relation of field to value. Valid operators:
+                                     ^: Begins with
+                                     *: Contains
+                                     ==: Equal to (or field does not exist, if value is None)
+                                     !=: Not equal to (or field exists, if value is None)
+                                     >: Greater than
+                                     >=: Greater than or equal to
+                                     <: Less than
+                                     <=: Less than or equal to
+                                     []: Between, inclusive (requires a list of two values)
+                                     in: Is one of the values (requires a list of values)
+                                         This operator effectively allows OR-ing '=='
+                           value: The value of the field.
+
+    Returns:
+    dict: The results of the scan.
+        success (bool): True on success, False otherwise.
+        results (list of dict): The status entries returned.
+        error (str): If success is False, the error that occurred.
+    """
+    # Get Dynamo status table
+    tbl_res = get_dmo_table(table_name)
+    if not tbl_res["success"]:
+        return tbl_res
+    table = tbl_res["table"]
+
+    # Translate fields
+    if isinstance(fields, str) or fields is None:
+        proj_exp = fields
+    elif isinstance(fields, list):
+        proj_exp = ",".join(fields)
+    else:
+        return {
+            "success": False,
+            "error": "Invalid fields type {}: '{}'".format(type(fields), fields)
+        }
+
+    # Translate filters
+    # 0 = field
+    # 1 = operator
+    # 2 = value
+    if isinstance(filters, tuple):
+        filters = [filters]
+    if filters is None or (isinstance(filters, list) and len(filters) == 0):
+        filter_exps = None
+    elif isinstance(filters, list):
+        filter_exps = []
+        for fil in filters:
+            # Begins with
+            if fil[1] == "^":
+                filter_exps.append(Attr(fil[0]).begins_with(fil[2]))
+            # Contains
+            elif fil[1] == "*":
+                filter_exps.append(Attr(fil[0]).contains(fil[2]))
+            # Equal to (or field does not exist, if value is None)
+            elif fil[1] == "==":
+                if fil[2] is None:
+                    filter_exps.append(Attr(fil[0]).not_exists())
+                else:
+                    filter_exps.append(Attr(fil[0]).eq(fil[2]))
+            # Not equal to (or field exists, if value is None)
+            elif fil[1] == "!=":
+                if fil[2] is None:
+                    filter_exps.append(Attr(fil[0]).exists())
+                else:
+                    filter_exps.append(Attr(fil[0]).ne(fil[2]))
+            # Greater than
+            elif fil[1] == ">":
+                filter_exps.append(Attr(fil[0]).gt(fil[2]))
+            # Greater than or equal to
+            elif fil[1] == ">=":
+                filter_exps.append(Attr(fil[0]).gte(fil[2]))
+            # Less than
+            elif fil[1] == "<":
+                filter_exps.append(Attr(fil[0]).lt(fil[2]))
+            # Less than or equal to
+            elif fil[1] == "<=":
+                filter_exps.append(Attr(fil[0]).lte(fil[2]))
+            # Between, inclusive (requires a list of two values)
+            elif fil[1] == "[]":
+                if not isinstance(fil[2], list) or len(fil[2]) != 2:
+                    return {
+                        "success": False,
+                        "error": "Invalid between ('[]') operator values: '{}'".format(fil[2])
+                    }
+                filter_exps.append(Attr(fil[0]).between(fil[2][0], fil[2][1]))
+            # Is one of the values (requires a list of values)
+            elif fil[1] == "in":
+                if not isinstance(fil[2], list):
+                    return {
+                        "success": False,
+                        "error": "Invalid 'in' operator values: '{}'".format(fil[2])
+                    }
+                filter_exps.append(Attr(fil[0]).is_in(fil[2]))
+            else:
+                return {
+                    "success": False,
+                    "error": "Invalid filter operator '{}'".format(fil[1])
+                }
+    else:
+        return {
+            "success": False,
+            "error": "Invalid filters type {}: '{}'".format(type(filters), filters)
+        }
+
+    # Make scan arguments
+    scan_args = {
+        "ConsistentRead": True
+    }
+    if proj_exp is not None:
+        scan_args["ProjectionExpression"] = proj_exp
+    if filter_exps is not None:
+        # Create valid FilterExpression
+        # Each Attr must be combined with &
+        filter_expression = filter_exps[0]
+        for i in range(1, len(filter_exps)):
+            filter_expression = filter_expression & filter_exps[i]
+        scan_args["FilterExpression"] = filter_expression
+
+    # Make scan call, paging through if too many entries are scanned
+    result_entries = []
+    while True:
+        scan_res = table.scan(**scan_args)
+        # Check for success
+        if scan_res["ResponseMetadata"]["HTTPStatusCode"] >= 300:
+            return {
+                "success": False,
+                "error": ("HTTP code {} returned: {}"
+                          .format(scan_res["ResponseMetadata"]["HTTPStatusCode"],
+                                  scan_res["ResponseMetadata"]))
+            }
+        # Add results to list
+        result_entries.extend(scan_res["Items"])
+        # Check for completeness
+        # If LastEvaluatedKey exists, need to page through more results
+        if scan_res.get("LastEvaluatedKey", None) is not None:
+            scan_args["ExclusiveStartKey"] = scan_res["LastEvaluatedKey"]
+        # Otherwise, all results retrieved
+        else:
+            break
+
+    return {
+        "success": True,
+        "results": result_entries
+    }
+
+
+def split_source_id(source_id):
+    """Retrieve the source_name and version information from a source_id.
+    Not complex logic, but easier to have in one location.
+    Standard form: {source_name}_v{search_version}.{submission_version}
+
+    Arguments:
+    source_id (str): The source_id to split. If this is not a valid-form source_id,
+                     the entire string will be assumed to be the source_name and source_id
+                     and the versions will be 0.
+
+    Returns:
+    dict:
+        success (bool): True if the versions were extracted, False otherwise.
+        source_name (str): The base source_name.
+        source_id (str): The assembled source_id.
+        search_version (int): The Search version from the source_id.
+        submission_version (int): The Connect version from the source_id.
+    """
+    # Check if source_id is valid
+    if not re.search("_v[0-9]+\\.[0-9]+$", source_id):
+        return {
+            "success": False,
+            "source_name": source_id,
+            "source_id": source_id,
+            "search_version": 0,
+            "submission_version": 0
+        }
+
+    source_name, versions = source_id.rsplit("_v", 1)
+    v_info = versions.split(".", 1)
+    search_version, submission_version = v_info
+
+    return {
+        "success": True,
+        "source_name": source_name,
+        "source_id": "{}_v{}.{}".format(source_name, search_version, submission_version),
+        "search_version": int(search_version),
+        "submission_version": int(submission_version)
+    }
+
+
+def translate_automate_status(status):
+    """Translate Automate's status message into an MDF status message."""
+    # TODO (XTH)
+    raise NotImplementedError
+
+
+def validate_sub_log(entry):
+    """Validate a submission log entry.
+
+    Arguments:
+        entry (dict): The entry to validate.
+
+    Returns:
+        dict:
+            success (bool): True if the status is valid, False otherwise.
+            error (str): When the status is not valid, the reason why.
+            details (str): Optional verbose details about an error.
+    """
+    # TODO (XTH): Sub log schema
+    raise NotImplementedError
+    # Load schema
+    with open(os.path.join(CONFIG["SCHEMA_PATH"], "internal_sub_log.json")) as schema_file:
+        schema = json.load(schema_file)
+    resolver = jsonschema.RefResolver(base_uri="file://{}/".format(CONFIG["SCHEMA_PATH"]),
+                                      referrer=schema)
+    # Validate entry
+    try:
+        jsonschema.validate(entry, schema, resolver=resolver)
+    except jsonschema.ValidationError as e:
+        return {
+            "success": False,
+            "error": "Invalid submission log entry: {}".format(str(e).split("\n")[0]),
+            "details": str(e)
+        }
+    else:
+        return {
+            "success": True,
+            "error": None,
+            "details": None
+        }

--- a/mdf_connect_server/utils/api_utils.py
+++ b/mdf_connect_server/utils/api_utils.py
@@ -134,8 +134,8 @@ def authenticate_token(token, groups, require_all=False):
             auth_succeeded = True
         else:
             # Translate convert and admin groups
-            if grp.lower() == "convert":
-                grp = CONFIG["CONVERT_GROUP_ID"]
+            if grp.lower() == "extract" or grp.lower() == "convert":
+                grp = CONFIG["EXTRACT_GROUP_ID"]
             elif grp.lower() == "admin":
                 grp = CONFIG["ADMIN_GROUP_ID"]
             # Group membership checks - each identity with each group
@@ -389,7 +389,7 @@ def fetch_org_rules(org_names, user_rules=None):
         organizations = json.load(f)
 
     # Cache list of all organization aliases to match against
-    # Transform into tuple (normalized_aliases, org_rules) for convenience
+    # Turn into tuple (normalized_aliases, org_rules) for convenience
     all_clean_orgs = []
     for org in organizations:
         aliases = [normalize_name(alias) for alias in (org.get("aliases", [])

--- a/mdf_connect_server/utils/integrations.py
+++ b/mdf_connect_server/utils/integrations.py
@@ -1,6 +1,7 @@
 # TODO: Can FuncX functions call each other like this?
 # TODO: How to keep DataCite credentials secret on FuncX?
 
+
 def citrine_upload(citrine_data, api_key, mdf_dataset, previous_id=None, public=True):
     import os
     from citrination_client import CitrinationClient

--- a/mdf_connect_server/utils/integrations.py
+++ b/mdf_connect_server/utils/integrations.py
@@ -1,0 +1,247 @@
+# TODO: Can FuncX functions call each other like this?
+# TODO: How to keep DataCite credentials secret on FuncX?
+
+def citrine_upload(citrine_data, api_key, mdf_dataset, previous_id=None, public=True):
+    import os
+    from citrination_client import CitrinationClient
+
+    cit_client = CitrinationClient(api_key).data
+    source_id = mdf_dataset.get("mdf", {}).get("source_id", "NO_ID")
+    try:
+        cit_title = mdf_dataset["dc"]["titles"][0]["title"]
+    except (KeyError, IndexError, TypeError):
+        cit_title = "Untitled"
+    try:
+        cit_desc = " ".join([desc["description"]
+                             for desc in mdf_dataset["dc"]["descriptions"]])
+        if not cit_desc:
+            raise KeyError
+    except (KeyError, IndexError, TypeError):
+        cit_desc = None
+
+    # Create new version if dataset previously created
+    if previous_id:
+        try:
+            rev_res = cit_client.create_dataset_version(previous_id)
+            assert rev_res.number > 1
+        except Exception:
+            previous_id = "INVALID"
+        else:
+            cit_ds_id = previous_id
+            cit_client.update_dataset(cit_ds_id,
+                                      name=cit_title,
+                                      description=cit_desc,
+                                      public=False)
+    # Create new dataset if not created
+    if not previous_id or previous_id == "INVALID":
+        try:
+            cit_ds_id = cit_client.create_dataset(name=cit_title,
+                                                  description=cit_desc,
+                                                  public=False).id
+            assert cit_ds_id > 0
+        except Exception as e:
+            print("{}: Citrine dataset creation failed: {}".format(source_id, repr(e)))
+            if previous_id == "INVALID":
+                return {
+                    "success": False,
+                    "error": "Unable to create revision or new dataset in Citrine"
+                }
+            else:
+                return {
+                    "success": False,
+                    "error": "Unable to create Citrine dataset, possibly due to duplicate entry"
+                }
+
+    success = 0
+    failed = 0
+    for path, _, files in os.walk(os.path.abspath(citrine_data)):
+        for pif in files:
+            up_res = cit_client.upload(cit_ds_id, os.path.join(path, pif))
+            if up_res.successful():
+                success += 1
+            else:
+                print("{}: Citrine upload failure: {}".format(source_id, str(up_res)))
+                failed += 1
+
+    cit_client.update_dataset(cit_ds_id, public=public)
+
+    return {
+        "success": bool(success),
+        "cit_ds_id": cit_ds_id,
+        "success_count": success,
+        "failure_count": failed
+        }
+
+
+def datacite_mint_doi(dc_md, test, url=None, doi=None):
+    import json
+    import requests
+
+    if not doi and not dc_md.get("identifier") and not dc_md.get("identifiers"):
+        doi = make_dc_doi(test)
+
+    doi_md = translate_dc_schema(dc_md, doi=doi, url=url)
+    creds = get_dc_creds(test)
+    res = requests.post(creds["DC_URL"], auth=(creds["DC_USERNAME"], creds["DC_PASSWORD"]),
+                        json=doi_md)
+    try:
+        res_json = res.json()
+    except json.JSONDecodeError:
+        return {
+            "success": False,
+            "error": "DOI minting failed",
+            "details": res.content
+        }
+
+    if res.status_code >= 300:
+        return {
+            "success": False,
+            "error": "; ".join([err["title"] for err in res_json["errors"]])
+        }
+    else:
+        return {
+            "success": True,
+            # "datacite_full": res_json,
+            # "dataset": doi_md,
+            "datacite": res_json["data"]
+        }
+
+
+def datacite_update_doi(doi, updates, test, url=None):
+    import json
+    import requests
+
+    update_md = translate_dc_schema(updates, doi=doi, url=url)
+    creds = get_dc_creds(test)
+    res = requests.put(creds["DC_URL"]+doi, auth=(creds["DC_USERNAME"], creds["DC_PASSWORD"]),
+                       json=update_md)
+    try:
+        res_json = res.json()
+    except json.JSONDecodeError:
+        return {
+            "success": False,
+            "error": "DOI update failed",
+            "details": res.content
+        }
+
+    if res.status_code >= 300:
+        return {
+            "success": False,
+            "error": "; ".join([err["title"] for err in res_json["errors"]])
+        }
+    else:
+        return {
+            "success": True,
+            "datacite": res_json["data"]
+        }
+
+
+def get_dc_creds(test):
+    # TODO
+    raise NotImplementedError
+    '''
+    if test:
+        return CONFIG["DATACITE_CREDS"]["TEST"]
+    else:
+        return CONFIG["DATACITE_CREDS"]["NONTEST"]
+    '''
+
+
+def make_dc_doi(test, num_sections, num_chars):
+    """Create a random (but unused) DOI.
+
+    Arguments:
+        test (bool): Generate a test DOI?
+        num_sections (int): Number of sections of random characters to add.
+                (ex. 10.123/xxxx-xxxx-xxxx is three sections of four characters)
+        num_chars (int): Number of characters per section.
+
+    Returns:
+        str: The generated DOI.
+    """
+    import random
+    import string
+    import requests
+
+    creds = get_dc_creds(test)
+    doi_unique = False
+    while not doi_unique:
+        # Create new DOI by appending random characters to prefix
+        new_doi = creds["DC_PREFIX"]
+        for i in range(num_sections):
+            new_doi += "".join(random.choices(string.ascii_lowercase + string.digits,
+                                              k=num_chars))
+            new_doi += "-"
+        new_doi = new_doi.strip("-")
+
+        # Check that new_doi is unique, not used previously
+        # NOTE: Technically there is a non-zero chance that two identical IDs are generated
+        #       before either submit to DataCite.
+        #       However, the probability is low enough that we do not mitigate this
+        #       condition. Should it occur, the later submission will fail.
+        doi_fetch = requests.get(creds["DC_URL"]+new_doi)
+        if doi_fetch.status_code == 404:
+            doi_unique = True
+    return new_doi
+
+
+def translate_dc_schema(dc_md, doi=None, url=None):
+    """Translate Datacite Schema to Datacite DOI Schema (slightly different)."""
+    from copy import deepcopy
+
+    doi_data = deepcopy(dc_md)
+
+    # url
+    if url:
+        doi_data["url"] = url
+
+    # identifiers
+    if doi_data.get("identifier"):
+        doi_data["doi"] = doi_data["identifier"]["identifier"]
+        doi_data["identifiers"] = [doi_data.pop("identifier")]
+    elif doi:
+        doi_data["doi"] = doi
+        doi_data["identifiers"] = [{
+            "identifier": doi,
+            "identifierType": "DOI"
+        }]
+
+    # creators
+    if doi_data.get("creators"):
+        new_creators = []
+        for creator in doi_data["creators"]:
+            if creator.get("creatorName"):
+                creator["name"] = creator.pop("creatorName")
+            if creator.get("affiliations"):
+                creator["affiliation"] = creator.pop("affiliations")
+            new_creators.append(creator)
+        doi_data["creators"] = new_creators
+
+    # contributors
+    if doi_data.get("contributors"):
+        new_contributors = []
+        for contributor in doi_data["contributors"]:
+            if contributor.get("contributorName"):
+                contributor["name"] = contributor.pop("contributorName")
+            if contributor.get("affiliations"):
+                contributor["affiliation"] = contributor.pop("affiliations")
+            new_contributors.append(contributor)
+        doi_data["contributors"] = new_contributors
+
+    # types
+    if doi_data.get("resourceType"):
+        doi_data["types"] = doi_data.pop("resourceType")
+
+    # alternateIdentifiers (does not exist)
+    if doi_data.get("alternateIdentifiers"):
+        doi_data.pop("alternateIdentifiers")
+
+    doi_data["event"] = "publish"
+    doi_md = {
+        "data": {
+            "type": "dois",
+            "attributes": doi_data
+        }
+    }
+
+    return doi_md

--- a/mdf_connect_server/utils/utils.py
+++ b/mdf_connect_server/utils/utils.py
@@ -947,8 +947,7 @@ def normalize_globus_uri(location):
     """
     loc_info = urllib.parse.urlparse(location)
     # Globus Web App link into globus:// form
-    if (location.startswith("https://www.globus.org/app/transfer")
-            or location.startswith("https://app.globus.org/file-manager")):
+    if any([re.search(pattern, location) for pattern in CONFIG["GLOBUS_LINK_FORMS"]]):
         data_info = urllib.parse.unquote(loc_info.query)
         # EP ID is in origin or dest
         ep_start = data_info.find("origin_id=")

--- a/mdf_connect_server/utils/utils.py
+++ b/mdf_connect_server/utils/utils.py
@@ -65,7 +65,7 @@ STATUS_STEPS = (
     ("sub_start", "Submission initialization"),
     ("data_download", "Connect data download"),
     ("data_transfer", "Data transfer to primary destination"),
-    ("converting", "Metadata extraction"),
+    ("extracting", "Metadata extraction"),
     ("curation", "Dataset curation"),
     ("ingest_search", "MDF Search ingestion"),
     ("ingest_backup", "Data transfer to secondary destinations"),
@@ -173,8 +173,8 @@ def authenticate_token(token, groups, require_all=False):
             auth_succeeded = True
         else:
             # Translate convert and admin groups
-            if grp.lower() == "convert":
-                grp = CONFIG["CONVERT_GROUP_ID"]
+            if grp.lower() == "extract" or grp.lower() == "convert":
+                grp = CONFIG["EXTRACT_GROUP_ID"]
             elif grp.lower() == "admin":
                 grp = CONFIG["ADMIN_GROUP_ID"]
             # Group membership checks - each identity with each group
@@ -510,7 +510,7 @@ def fetch_org_rules(org_names, user_rules=None):
         organizations = json.load(f)
 
     # Cache list of all organization aliases to match against
-    # Transform into tuple (normalized_aliases, org_rules) for convenience
+    # Turn into tuple (normalized_aliases, org_rules) for convenience
     all_clean_orgs = []
     for org in organizations:
         aliases = [normalize_name(alias) for alias in (org.get("aliases", [])

--- a/mdf_connect_server/utils/utils.py
+++ b/mdf_connect_server/utils/utils.py
@@ -303,7 +303,7 @@ def make_source_id(title, author, test=False, index=None, sanitize_only=False):
         author_word += clean_token
 
     # Remove author_word from title, if exists (e.g. from previous make_source_id())
-    while author_word in title_clean:
+    while author_word in title_clean and not sanitize_only:
         title_clean.remove(author_word)
 
     # Select words from title for source_name

--- a/mdf_connect_server/utils/utils.py
+++ b/mdf_connect_server/utils/utils.py
@@ -64,8 +64,8 @@ DMO_SCHEMA = {
 STATUS_STEPS = (
     ("sub_start", "Submission initialization"),
     ("data_download", "Connect data download"),
-    ("data_transfer", "Primary data transfer"),
-    ("converting", "Data conversion"),
+    ("data_transfer", "Data transfer to primary destination"),
+    ("converting", "Metadata extraction"),
     ("curation", "Dataset curation"),
     ("ingest_search", "MDF Search ingestion"),
     ("ingest_backup", "Data transfer to secondary destinations"),
@@ -82,7 +82,6 @@ SUCCESS_CODES = [
     "M",
     "L",
     "R",
-    "U",
     "N"
 ]
 
@@ -1797,8 +1796,6 @@ def update_status(source_id, step, code, text=None, link=None, except_on_fail=Fa
         code_list = code_list[:step_index+1] + ["X"]*len(code_list[step_index+1:])
     elif code == 'R':
         status["messages"][step_index] = (text or "An error occurred but we're recovering")
-    elif code == 'U':
-        status["messages"][step_index] = (text or "Processing will continue")
     elif code == 'T':
         status["messages"][step_index] = (text or "Retrying")
     status["code"] = "".join(code_list)
@@ -1944,13 +1941,6 @@ def translate_status(status):
             usr_msg += msg + "\n"
             web_msg.append({
                 "signal": "failure",
-                "text": msg
-            })
-        elif code == 'U':
-            msg = "{} was unsuccessful: {}.".format(step, messages[index])
-            usr_msg += msg + "\n"
-            web_msg.append({
-                "signal": "warning",
                 "text": msg
             })
         elif code == 'H':

--- a/mdf_connect_server/utils/utils.py
+++ b/mdf_connect_server/utils/utils.py
@@ -293,6 +293,7 @@ def make_source_id(title, author, test=False, index=None, sanitize_only=False):
         # Clean token is lowercase and alphanumeric
         # TODO: After Py3.7 upgrade, use .isascii()
         clean_token = "".join([char for char in token.lower() if char.isalnum()])
+        # and char.isascii()])
         if clean_token and clean_token not in delete_words:
             title_clean.append(clean_token)
 
@@ -300,6 +301,7 @@ def make_source_id(title, author, test=False, index=None, sanitize_only=False):
     author_word = ""
     for token in author_tokens:
         clean_token = "".join([char for char in token.lower() if char.isalnum()])
+        # and char.isascii()])
         author_word += clean_token
 
     # Remove author_word from title, if exists (e.g. from previous make_source_id())
@@ -313,7 +315,8 @@ def make_source_id(title, author, test=False, index=None, sanitize_only=False):
     else:
         # Must have at least one word
         raise ValueError("Title '{}' invalid: Must have at least one word that is not "
-                         "the author name".format(title))
+                         "the author name (the following words do not count: '{}')"
+                         .format(title, delete_words))
     if len(title_clean) >= 2:
         word2 = title_clean[1]
     else:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         "flask>=1.0.2",
         "globus-sdk>=1.7.0",
         "gunicorn>=19.9.0",
-        "hyperspy>=1.4.1",
+        # "hyperspy>=1.4.1",  # Must be conda installed
         "jsonschema>=2.6.0",
         "mdf-toolbox>=0.5.0",
         "numpy>=1.16.0",

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -1,7 +1,7 @@
 import json
 import os
 
-import mdf_connect_server.processor.transformer as parsers
+import mdf_connect_server.processor.extractors as extractors
 import mdf_toolbox
 import pytest  # noqa: F401
 
@@ -67,12 +67,12 @@ def test_crystal_structure():
         }
     }
 
-    assert parsers.parse_crystal_structure([cif1_path]) == cif1_record
-    assert parsers.parse_crystal_structure([cif2_path]) == cif2_record
-    assert parsers.parse_crystal_structure([cif3_path]) == cif3_record
-    assert parsers.parse_crystal_structure([cif4_path]) == cif4_record
-    assert parsers.parse_crystal_structure([NO_DATA_FILE]) == {}
-    assert parsers.parse_crystal_structure([NA_PATH]) == {}
+    assert extractors.extract_crystal_structure([cif1_path]) == cif1_record
+    assert extractors.extract_crystal_structure([cif2_path]) == cif2_record
+    assert extractors.extract_crystal_structure([cif3_path]) == cif3_record
+    assert extractors.extract_crystal_structure([cif4_path]) == cif4_record
+    assert extractors.extract_crystal_structure([NO_DATA_FILE]) == {}
+    assert extractors.extract_crystal_structure([NA_PATH]) == {}
 
 
 def test_tdb():
@@ -134,14 +134,14 @@ def test_tdb():
         }
     }
 
-    assert mdf_toolbox.insensitive_comparison(parsers.parse_tdb([tdb1_path]), tdb1_record,
+    assert mdf_toolbox.insensitive_comparison(extractors.extract_tdb([tdb1_path]), tdb1_record,
                                               string_insensitive=True)
-    assert mdf_toolbox.insensitive_comparison(parsers.parse_tdb([tdb2_path]), tdb2_record,
+    assert mdf_toolbox.insensitive_comparison(extractors.extract_tdb([tdb2_path]), tdb2_record,
                                               string_insensitive=True)
-    assert mdf_toolbox.insensitive_comparison(parsers.parse_tdb([tdb3_path]), tdb3_record,
+    assert mdf_toolbox.insensitive_comparison(extractors.extract_tdb([tdb3_path]), tdb3_record,
                                               string_insensitive=True)
-    assert parsers.parse_tdb([NO_DATA_FILE]) == {}
-    assert parsers.parse_tdb([NA_PATH]) == {}
+    assert extractors.extract_tdb([NO_DATA_FILE]) == {}
+    assert extractors.extract_tdb([NA_PATH]) == {}
 
 
 def test_pif():
@@ -205,16 +205,16 @@ def test_json(tmpdir):
     }
 
     # Test with proper mappings
-    assert parsers.parse_json(group, params={
-                                        "parsers": {
+    assert extractors.extract_json(group, params={
+                                        "extractors": {
                                             "json": {
                                                 "mapping": mapping1,
                                                 "na_values": ["na"]
                                             }
                                         }
                                      }) == [correct_record]
-    assert parsers.parse_json(group, params={
-                                        "parsers": {
+    assert extractors.extract_json(group, params={
+                                        "extractors": {
                                             "json": {
                                                 "mapping": mapping2,
                                                 "na_values": "na"
@@ -222,8 +222,8 @@ def test_json(tmpdir):
                                         }
                                      }) == [correct_record]
     # With na included
-    assert parsers.parse_json(group, params={
-                                        "parsers": {
+    assert extractors.extract_json(group, params={
+                                        "extractors": {
                                             "json": {
                                                 "mapping": mapping1
                                             }
@@ -231,23 +231,23 @@ def test_json(tmpdir):
                                      }) == [with_na_record]
 
     # Test failure modes
-    assert parsers.parse_json(group, {}) == {}
-    assert parsers.parse_json([], params={
-                                    "parsers": {
+    assert extractors.extract_json(group, {}) == {}
+    assert extractors.extract_json([], params={
+                                    "extractors": {
                                         "json": {
                                             "mapping": mapping2
                                         }
                                     }
                                   }) == []
-    assert parsers.parse_json([NO_DATA_FILE], params={
-                                    "parsers": {
+    assert extractors.extract_json([NO_DATA_FILE], params={
+                                    "extractors": {
                                         "json": {
                                             "mapping": mapping2
                                         }
                                     }
                                   }) == []
-    assert parsers.parse_json([NA_PATH], params={
-                                    "parsers": {
+    assert extractors.extract_json([NA_PATH], params={
+                                    "extractors": {
                                         "json": {
                                             "mapping": mapping2
                                         }
@@ -298,38 +298,38 @@ def test_xml(tmpdir):
     }
 
     # Test with proper mappings
-    assert parsers.parse_xml(group, params={
-                                        "parsers": {
+    assert extractors.extract_xml(group, params={
+                                        "extractors": {
                                             "xml": {
                                                 "mapping": mapping1
                                             }
                                         }
                                      }) == [correct_record]
-    assert parsers.parse_xml(group, params={
-                                        "parsers": {
+    assert extractors.extract_xml(group, params={
+                                        "extractors": {
                                             "xml": {
                                                 "mapping": mapping2
                                             }
                                         }
                                      }) == [correct_record]
     # Test failure modes
-    assert parsers.parse_xml(group, {}) == {}
-    assert parsers.parse_xml([], params={
-                                    "parsers": {
+    assert extractors.extract_xml(group, {}) == {}
+    assert extractors.extract_xml([], params={
+                                    "extractors": {
                                         "xml": {
                                             "mapping": mapping2
                                         }
                                     }
                                   }) == []
-    assert parsers.parse_xml([NO_DATA_FILE], params={
-                                    "parsers": {
+    assert extractors.extract_xml([NO_DATA_FILE], params={
+                                    "extractors": {
                                         "xml": {
                                             "mapping": mapping2
                                         }
                                     }
                                   }) == []
-    assert parsers.parse_xml([NA_PATH], params={
-                                    "parsers": {
+    assert extractors.extract_xml([NA_PATH], params={
+                                    "extractors": {
                                         "xml": {
                                             "mapping": mapping2
                                         }
@@ -382,17 +382,17 @@ def test_filename():
             'composition': 'O2'
         }
     }]
-    assert parsers.parse_filename(group, params={
-                                            "parsers": {
+    assert extractors.extract_filename(group, params={
+                                            "extractors": {
                                                 "filename": {
                                                     "mapping": mapping
                                                 }
                                             }
                                          }) == correct
     # Failures
-    assert parsers.parse_filename(group, params={}) == {}
-    assert parsers.parse_filename([], params={
-                                            "parsers": {
+    assert extractors.extract_filename(group, params={}) == {}
+    assert extractors.extract_filename([], params={
+                                            "extractors": {
                                                 "filename": {
                                                     "mapping": mapping
                                                 }


### PR DESCRIPTION
- Split API utils from Processing utils
- Move non-extraction logic to API as possible
- Rename "parsers" to "extractors"

Misc:
- Fix removing author's name from user-supplied source_name
- Support Globus Web App-branded site links for Transfer, not just standard GWA Transfer links
- Remove "Unsuccessful" status, zero extracted records re-categorized as success