### PR TITLE
Introduce classes to wrap up automate flow interactions

### DIFF
--- a/automate/RunMDF_Flow.ipynb
+++ b/automate/RunMDF_Flow.ipynb
@@ -1,0 +1,263 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ[\"FLASK_ENV\"]='development'\n",
+    "\n",
+    "from mdf_connect_server.automate.globus_automate_flow import GlobusAutomateFlow\n",
+    "import mdf_toolbox\n",
+    "import json\n",
+    "import time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Globus Automate Flow: id=33af393f-4c5d-4031-ba2d-0c898de7c4fd, scope=https://auth.globus.org/scopes/33af393f-4c5d-4031-ba2d-0c898de7c4fd/flow_33af393f_4c5d_4031_ba2d_0c898de7c4fd_user\n"
+     ]
+    }
+   ],
+   "source": [
+    "native_app_id = \"417301b1-5101-456a-8a27-423e71a2ae26\"  # Premade native app ID\n",
+    "automate = GlobusAutomateFlow(native_app_id)\n",
+    "automate.read_flow(\"mdf_flow_info.json\")\n",
+    "\n",
+    "print(automate)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate input credentials\n",
+    "# The feedstock auth header is shorter-lived, so it's not set in the Flow defintition.\n",
+    "# However, the header must be from an identity with access to the Xtract output location (currently Petrel)\n",
+    "petrel_auth = mdf_toolbox.login(services=[\"petrel\"], make_clients=False)[\"petrel\"]\n",
+    "feedstock_auth_header = {}\n",
+    "petrel_auth.set_authorization_header(feedstock_auth_header)\n",
+    "feedstock_auth_header = feedstock_auth_header[\"Authorization\"]\n",
+    "\n",
+    "# The RunAs token is used to Transfer data from the user as the user's identity.\n",
+    "# It will be given by the MDF user (by logging in with MDF).\n",
+    "# NOTE: Currently, RunAs is not used on the Transfer.\n",
+    "run_as_auth = automate.get_runas_auth()\n",
+    "run_as_token = run_as_auth.refresh_token"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'mdf_flow_test_1606930993_v1.1'"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Get test input for Flow\n",
+    "with open(\"mdf_flow_input.json\") as f:\n",
+    "    flow_input = json.load(f)\n",
+    "\n",
+    "# Add credentials to input\n",
+    "flow_input[\"_private_feedstock_auth_header\"] = feedstock_auth_header\n",
+    "flow_input[\"_tokens\"] = {\"MDFUser\": run_as_token}\n",
+    "\n",
+    "# Create unique source_id for submission (source_id must be unique except for updates)\n",
+    "source_id = \"mdf_flow_test_\" + str(int(time.time())) + \"_v1.1\"\n",
+    "flow_input[\"source_id\"] = source_id\n",
+    "source_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flow = automate.run_flow(flow_input)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "    \"action_id\": \"a141115e-f938-4111-8b6f-769af74c9f94\",\n",
+      "    \"completion_time\": \"None\",\n",
+      "    \"created_by\": \"urn:globus:auth:identity:8dd693cf-f1a0-4ee4-8079-b69705523e6b\",\n",
+      "    \"details\": {\n",
+      "        \"code\": \"ActionStarted\",\n",
+      "        \"description\": \"State UserTransfer of type Action started\",\n",
+      "        \"details\": {\n",
+      "            \"input\": {\n",
+      "                \"action_inputs\": [\n",
+      "                    {\n",
+      "                        \"destination_endpoint_id\": \"e38ee745-6d04-11e5-ba46-22000b92c6ec\",\n",
+      "                        \"label\": \"MDF Flow Test Transfer1\",\n",
+      "                        \"source_endpoint_id\": \"e38ee745-6d04-11e5-ba46-22000b92c6ec\",\n",
+      "                        \"transfer_items\": [\n",
+      "                            {\n",
+      "                                \"destination_path\": \"/MDF/mdf_connect/test_files/deleteme/data/test123/\",\n",
+      "                                \"recursive\": true,\n",
+      "                                \"source_path\": \"/MDF/mdf_connect/test_files/canonical_datasets/dft/\"\n",
+      "                            }\n",
+      "                        ]\n",
+      "                    }\n",
+      "                ]\n",
+      "            },\n",
+      "            \"state_name\": \"UserTransfer\",\n",
+      "            \"state_type\": \"Action\"\n",
+      "        },\n",
+      "        \"time\": \"2020-12-02T17:43:15.187000+00:00\"\n",
+      "    },\n",
+      "    \"start_time\": \"2020-12-02T17:43:14.955000+00:00\",\n",
+      "    \"status\": \"ACTIVE\"\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(json.dumps(flow.get_status(), indent=4, sort_keys=True))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'code': 'ActionFailed', 'details': {'cause': '{\\'action_id\\': \\'46c3dee4-87de-448e-9460-cc8109c02ecc\\', \\'creator_id\\': \\'urn:globus:auth:identity:8dd693cf-f1a0-4ee4-8079-b69705523e6b\\', \\'details\\': {\\'message\\': \\'Action started\\'}, \\'errors\\': [\"error ingesting 46c3dee4-87de-448e-9460-cc8109c02ecc/mock_feedstock.json: (403, \\'Forbidden.Generic\\', \\'ingest request denied by service\\')\"], \\'manage_by\\': [\\'urn:globus:auth:identity:256d4736-e319-4ccc-b7d2-88f0cc2f8357\\', \\'urn:globus:auth:identity:4d40f211-15ac-4106-b8f5-e73dc093b5d5\\', \\'urn:globus:auth:identity:8dd693cf-f1a0-4ee4-8079-b69705523e6b\\'], \\'monitor_by\\': [\\'urn:globus:auth:identity:256d4736-e319-4ccc-b7d2-88f0cc2f8357\\', \\'urn:globus:auth:identity:4d40f211-15ac-4106-b8f5-e73dc093b5d5\\', \\'urn:globus:auth:identity:8dd693cf-f1a0-4ee4-8079-b69705523e6b\\'], \\'release_after\\': \\'P30D\\', \\'request_id\\': \\'flows_req_e60d29cd-c0c7-46c2-a234-12b04dea6f18\\', \\'status\\': \\'FAILED\\'}'}, 'time': '2020-12-02T17:43:56.497000+00:00'}\n",
+      "failure: <class 'str'>\n",
+      "{'action_id': '46c3dee4-87de-448e-9460-cc8109c02ecc', 'creator_id': 'urn:globus:auth:identity:8dd693cf-f1a0-4ee4-8079-b69705523e6b', 'details': {'message': 'Action started'}, 'errors': [\"error ingesting 46c3dee4-87de-448e-9460-cc8109c02ecc/mock_feedstock.json: (403, 'Forbidden.Generic', 'ingest request denied by service')\"], 'manage_by': ['urn:globus:auth:identity:256d4736-e319-4ccc-b7d2-88f0cc2f8357', 'urn:globus:auth:identity:4d40f211-15ac-4106-b8f5-e73dc093b5d5', 'urn:globus:auth:identity:8dd693cf-f1a0-4ee4-8079-b69705523e6b'], 'monitor_by': ['urn:globus:auth:identity:256d4736-e319-4ccc-b7d2-88f0cc2f8357', 'urn:globus:auth:identity:4d40f211-15ac-4106-b8f5-e73dc093b5d5', 'urn:globus:auth:identity:8dd693cf-f1a0-4ee4-8079-b69705523e6b'], 'release_after': 'P30D', 'request_id': 'flows_req_e60d29cd-c0c7-46c2-a234-12b04dea6f18', 'status': 'FAILED'}\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[[\"error ingesting 46c3dee4-87de-448e-9460-cc8109c02ecc/mock_feedstock.json: (403, 'Forbidden.Generic', 'ingest request denied by service')\"]]"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "flow.get_error_msgs()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'a141115e-f938-4111-8b6f-769af74c9f94'"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "flow.action_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<mdf_connect_server.automate.globus_automate_flow.GlobusAutomateFlow at 0x111691ed0>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "automate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Globus Automate Flow: id=33af393f-4c5d-4031-ba2d-0c898de7c4fd, scope=https://auth.globus.org/scopes/33af393f-4c5d-4031-ba2d-0c898de7c4fd/flow_33af393f_4c5d_4031_ba2d_0c898de7c4fd_user\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(automate)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/automate/deploy_mdf_flow.py
+++ b/automate/deploy_mdf_flow.py
@@ -1,0 +1,126 @@
+import json
+import os
+# Do this to get deal with the mdf_connect_server package init assumptions
+os.environ["FLASK_ENV"]='development'
+
+
+from mdf_connect_server.automate.globus_automate_flow import GlobusAutomateFlow
+
+automate = GlobusAutomateFlow(native_app_id="417301b1-5101-456a-8a27-423e71a2ae26")
+
+# Required secret keys for deploying Flow (not in Flow definition JSON)
+from getpass import getpass
+smtp_user = getpass("SMTP Username: ")
+smtp_pass = getpass("SMTP Password: ")
+smtp_hostname = "email-smtp.us-east-1.amazonaws.com"
+smtp_send_credentials = [{
+    # "credential_method": "",
+    "credential_type": "smtp",
+    "credential_value": {
+        "hostname": smtp_hostname,
+        "username": smtp_user,
+        "password": smtp_pass
+    }
+}]
+
+# Schemas of different APs for reference
+transfer_input_schema = {
+    # "deadline": "datetime str",
+    "destination_endpoint_id": "str",
+    "label": "str",
+    "source_endpoint_id": "str",
+    # "sync_level": "str 0-3",
+    "transfer_items": [{
+        "destination_path": "str",
+        "recursive": "bool",
+        "source_path": "str"
+    }]
+}
+transfer_permission_schema = {
+    "endpoint_id": "string",
+    "operation": "string",
+    "path": "string",
+    "permissions": "string",
+    "principal": "string",
+    "principal_type": "string"
+}
+curation_input_schema = {
+    "curator_emails": "list of str, or False",
+    "curator_template": "str or False",  # variables: $landing_page
+    "curation_permissions": "list of str",
+    "curation_text": "str or False",
+    "author_email": "str or False",
+    "author_template": "str or False",  # variables: $curation_task_id, $decision, $reason
+    "email_sender": "str",
+    "send_credentials": [{}]
+}
+xtract_input_schema = {
+    "metadata_storage_ep": "str",
+    "eid": "str",
+    "dir_path": "str",
+    "mapping": "match",  # ?
+    "dataset_mdata": {"test1": "test2"},
+    "validator_params": {"schema_branch": "master", "validation_info": {"test1": "test2"}},
+    "grouper": "matio"  # options are 'directory/matio'
+}
+
+# Load MDF Flow definition from JSON
+with open("mdf_flow_def.json") as f:
+    mdf_flow_def = json.load(f)
+# Add required secret keys
+mdf_flow_def["definition"]["States"]["ExceptionState"]["Parameters"]["send_credentials"] = smtp_send_credentials
+mdf_flow_def["definition"]["States"]["NotifyUserEnd"]["Parameters"]["send_credentials"] = smtp_send_credentials
+
+# Load other configuration variables
+# Please set these in the configuration file, not in-line here
+with open("mdf_flow_config.json") as f:
+    config = json.load(f)
+# Permissions (both groups are MDF Connect Admins, for now)
+mdf_flow_def["visible_to"] = config["flow_permissions"]
+mdf_flow_def["runnable_by"] = config["flow_permissions"]
+mdf_flow_def["administered_by"] = config["admin_permissions"]
+# Curation and Transfer Loop subflows (see MDF Utility Flows)
+mdf_flow_def["definition"]["States"]["UserTransfer"]["ActionUrl"] = config["transfer_loop_url"]
+mdf_flow_def["definition"]["States"]["UserTransfer"]["ActionScope"] = config["transfer_loop_scope"]
+mdf_flow_def["definition"]["States"]["DataDestTransfer"]["ActionUrl"] = config["transfer_loop_url"]
+mdf_flow_def["definition"]["States"]["DataDestTransfer"]["ActionScope"] = config["transfer_loop_scope"]
+mdf_flow_def["definition"]["States"]["CurateSubmission"]["ActionUrl"] = config["curation_subflow_url"]
+mdf_flow_def["definition"]["States"]["CurateSubmission"]["ActionScope"] = config["curation_subflow_scope"]
+# Config for emails
+# admin_email gets notified of critical exceptions in the Flow
+mdf_flow_def["definition"]["States"]["ExceptionState"]["Parameters"]["destination"] = config["admin_email"]
+# sender_email is the address to send emails with (materialsdatafacility@gmail.com)
+mdf_flow_def["definition"]["States"]["ExceptionState"]["Parameters"]["sender"] = config["sender_email"]
+mdf_flow_def["definition"]["States"]["NotifyUserEnd"]["Parameters"]["sender"] = config["sender_email"]
+
+# Until Xtract AP is operational, mock the dataset entry output for Xtract AP
+mock_dataset_entry = {'dc': {'titles': [{'title': 'Base Deploy Testing Dataset'}],
+  'creators': [{'creatorName': 'jgaff',
+    'familyName': '',
+    'givenName': 'jgaff',
+    'affiliations': ['UChicago']}],
+  'publisher': 'Materials Data Facility',
+  'publicationYear': '2020',
+  'resourceType': {'resourceTypeGeneral': 'Dataset',
+   'resourceType': 'Dataset'}},
+ 'mdf': {'source_id': '_test_base_deploy_testing_v5.1',
+  'source_name': '_test_base_deploy_testing',
+  'version': 5,
+  'acl': ['public'],
+  'scroll_id': 0,
+  'ingest_date': '2020-05-06T17:47:05.219450Z',
+  'resource_type': 'dataset'},
+ 'data': {'endpoint_path': 'globus://e38ee745-6d04-11e5-ba46-22000b92c6ec/MDF/mdf_connect/prod/data/_test_base_deploy_testing_v5.1/',
+  'link': 'https://app.globus.org/file-manager?origin_id=e38ee745-6d04-11e5-ba46-22000b92c6ec&origin_path=/MDF/mdf_connect/prod/data/_test_base_deploy_testing_v5.1/',
+  'total_size': 4709193},
+ 'services': {}}
+
+mdf_flow_def["definition"]["States"]["Xtraction"]["Parameters"]["details"] = {
+    "output_link": "https://e38ee745-6d04-11e5-ba46-22000b92c6ec.e.globus.org/MDF/mdf_connect/test_files/mock_feedstock.json",
+    "dataset_entry": mock_dataset_entry
+}
+
+automate.deploy_mdf_flow(mdf_flow_def)
+automate.save_flow("mdf_flow_info.json")
+
+print("MDF Flow deployed", automate)

--- a/automate/requirements.txt
+++ b/automate/requirements.txt
@@ -1,0 +1,2 @@
+globus_automate_client
+mdf_toolbox

--- a/mdf_connect_server/__init__.py
+++ b/mdf_connect_server/__init__.py
@@ -3,12 +3,18 @@ import os
 from mdf_toolbox import dict_merge
 
 from mdf_connect_server.config import (DEFAULT, DEV, GLOBUS_HTTP_HOSTS,
-                                       GROUPINGS, KEYS, PROD)
+                                       GROUPINGS, PROD)
+
+try:
+    from mdf_connect_server.config import KEYS
+except ImportError:
+    KEYS = None
 
 
 CONFIG = {}
 CONFIG = dict_merge(DEFAULT, CONFIG)
-CONFIG = dict_merge(KEYS, CONFIG)
+if KEYS:
+    CONFIG = dict_merge(KEYS, CONFIG)
 
 server = os.environ.get("FLASK_ENV")
 if server == "production":
@@ -21,10 +27,12 @@ else:
 CONFIG["GLOBUS_HTTP_HOSTS"] = GLOBUS_HTTP_HOSTS
 CONFIG["GROUPING_RULES"] = GROUPINGS
 # Add credentials
-CONFIG["GLOBUS_CREDS"] = {
-    "client_id": CONFIG["API_CLIENT_ID"],
-    "client_secret": CONFIG["API_CLIENT_SECRET"]
-}
+
+if "API_CLIENT_SECRET" in CONFIG:
+    CONFIG["GLOBUS_CREDS"] = {
+        "client_id": CONFIG["API_CLIENT_ID"],
+        "client_secret": CONFIG["API_CLIENT_SECRET"]
+    }
 
 # Make required dirs
 os.makedirs(CONFIG["LOCAL_PATH"], exist_ok=True)

--- a/mdf_connect_server/automate/__init__.py
+++ b/mdf_connect_server/automate/__init__.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2019, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/mdf_connect_server/automate/flow_action.py
+++ b/mdf_connect_server/automate/flow_action.py
@@ -1,0 +1,22 @@
+import ast
+
+
+class FlowAction:
+    def __init__(self, flow, action_id: str):
+        self.action_id = action_id
+        self.flow = flow
+
+    def get_status(self):
+        return self.flow.get_status(self.action_id)
+
+    def get_error_msgs(self):
+        logs = self.flow.get_flow_logs(self.action_id)
+        error_msgs = []
+        for failure in filter(lambda x: x['code'] == 'ActionFailed', logs['entries']):
+            # Failures from Search Ingest Action Provider are bundled up as string
+            # representation of Python dict
+            cause = ast.literal_eval(failure['details']['cause'])
+            if 'errors' in cause:
+                error_msgs.append(cause['errors'])
+
+        return error_msgs

--- a/mdf_connect_server/automate/globus_automate_flow.py
+++ b/mdf_connect_server/automate/globus_automate_flow.py
@@ -1,0 +1,69 @@
+import json
+
+import globus_automate_client
+import mdf_toolbox
+
+from mdf_connect_server.automate.flow_action import FlowAction
+
+
+class GlobusAutomateFlow:
+    def __init__(self, native_app_id: str, flow_id: str = None, flow_scope: str = None):
+        self.flows_client = globus_automate_client.create_flows_client(native_app_id)
+        self.flow_id = flow_id
+        self.flow_scope = flow_scope
+
+    def __str__(self):
+        return f'Globus Automate Flow: id={self.flow_id}, scope={self.flow_scope}'
+
+    def get_runas_auth(self):
+        return mdf_toolbox.login(
+            services=[self.flow_scope],
+            make_clients=False)[self.flow_scope]
+
+    def get_status(self, action_id: str):
+        return self.flows_client.flow_action_status(
+            self.flow_id,
+            self.flow_scope,
+            action_id).data
+
+    def get_flow_logs(self, action_id: str):
+        return self.flows_client.flow_action_log(
+            self.flow_id, self.flow_scope,
+            action_id,
+            limit=100).data
+
+    def deploy_mdf_flow(self, mdf_flow_def):
+        flow_deploy_res = self.flows_client.deploy_flow(
+            flow_definition=mdf_flow_def["definition"],
+            title=mdf_flow_def["title"],
+            description=mdf_flow_def["description"],
+            visible_to=mdf_flow_def["visible_to"],
+            runnable_by=mdf_flow_def["runnable_by"],
+            administered_by=mdf_flow_def["administered_by"],
+            # TODO: Make rough schema outline into JSONSchema
+            input_schema={},  # mdf_flow_def["schema"],
+            validate_definition=True,
+            validate_input_schema=True
+        )
+        self.flow_id = flow_deploy_res["id"]
+        self.flow_scope = flow_deploy_res["globus_auth_scope"]
+
+    def run_flow(self, flow_input: dict):
+        flow_res = self.flows_client.run_flow(self.flow_id, self.flow_scope, flow_input)
+        return FlowAction(self, flow_res.data['action_id'])
+
+    def save_flow(self, path):
+        # Save Flow ID/scope for future use
+        with open(path, 'w') as f:
+            flow_info = {
+                "flow_id": self.flow_id,
+                "flow_scope": self.flow_scope
+            }
+            json.dump(flow_info, f)
+
+    def read_flow(self, path):
+        # Save Flow ID/scope for future use
+        with open(path, 'r') as f:
+            flow_info = json.load(f)
+            self.flow_id = flow_info['flow_id']
+            self.flow_scope = flow_info['flow_scope']

--- a/mdf_connect_server/config/__init__.py
+++ b/mdf_connect_server/config/__init__.py
@@ -4,5 +4,8 @@ from .default import DEFAULT
 from .dev import DEV
 from .globus_http_hosts import GLOBUS_HTTP_HOSTS
 from .groupings import GROUPINGS
-from .keys import KEYS
+try:
+    from .keys import KEYS
+except ModuleNotFoundError:
+    pass
 from .prod import PROD

--- a/mdf_connect_server/config/default.py
+++ b/mdf_connect_server/config/default.py
@@ -71,7 +71,16 @@ DEFAULT = {
     "ADMIN_GROUP_ID": "5fc63928-3752-11e8-9c6f-0e00fd09bf20",
     "EXTRACT_GROUP_ID": "cc192dca-3751-11e8-90c1-0a7c735d220a"
 }
-with open(os.path.join(DEFAULT["SCHEMA_PATH"], "mrr_template.xml")) as f:
-    DEFAULT["MRR_TEMPLATE"] = f.read()
-with open(os.path.join(DEFAULT["SCHEMA_PATH"], "mrr_contributor.xml")) as f:
-    DEFAULT["MRR_CONTRIBUTOR"] = f.read()
+
+try:
+    with open(os.path.join(DEFAULT["SCHEMA_PATH"], "mrr_template.xml")) as f:
+        DEFAULT["MRR_TEMPLATE"] = f.read()
+except FileNotFoundError:
+    DEFAULT["MRR_TEMPLATE"] = None
+
+try:
+    with open(os.path.join(DEFAULT["SCHEMA_PATH"], "mrr_contributor.xml")) as f:
+        DEFAULT["MRR_CONTRIBUTOR"] = f.read()
+except FileNotFoundError:
+    DEFAULT["MRR_CONTRIBUTOR"] = None
+

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         # "hyperspy>=1.4.1",  # Must be conda installed
         "jsonschema>=2.6.0",
         "mdf-toolbox>=0.5.0",
+        "globus_automate_client",
         "numpy>=1.16.0",
         "pandas>=0.23.0",
         "pif-ingestor>=1.1.1",


### PR DESCRIPTION
# Problem
There is a fair amount of code and IDs required to interact with the automate SDK. Some of the return values from automate are inconsistent and need massaging to be useable.

# Approach
Create two classes to represent interactions with the SDK
1. GlobusAutomateFlow - This class holds the flow client connection and keeps track of the flow_id and the flow_scope. These values are populated when you pass in a flow definition and have the class register it with Globus Automate. The values can be persisted to a local json file and read back in to access a previously deployed flow. The class supports setting `runAs` auth values as well as for launching a flow instance.
2. FlowAction - This is a running instance of a flow. It is constructed by executing the GlobusAutomateFlow's `run_flow` method. The class offers a wrapper for status messages as well as a method for finding the error message from the flow's logs.

To make it easier to deploy the MDF flow, I created a script called `deploy_mdf_flow.py` - I discovered that the MDF_Connect_Server's module __init__ assumes the module is only ever used in the context of a Flask app. Add some light checks to allow it to be initialized in a command line.

Finally, created a simple notebook that just runs an MDF flow, picking up the flow_id and flow_scope from `mdf_flow_info.json` - it uses the class library to fetch the error message I currently get from Search Ingest