### PR TITLE
Fix returned version

### DIFF
--- a/aws/submit_dataset.py
+++ b/aws/submit_dataset.py
@@ -585,6 +585,6 @@ def lambda_handler(event, context):
             {
                 "success": True,
                 'source_id': source_name,
-                'version': version
+                'version': status_info['version']
             })
     }

--- a/aws/tests/submit_dataset.feature
+++ b/aws/tests/submit_dataset.feature
@@ -10,7 +10,7 @@ Feature: Submit Dataset
         And the dynamo record should be version 1.0
         And an automate flow started
         And the data destination should be the Petrel MDF directory
-        And I should receive a success result with the generated uuid
+        And I should receive a success result with the generated uuid and version 1.0
 
     Scenario: Submit Dataset With Provided source_id
         Given I'm authenticated with MDF
@@ -21,7 +21,7 @@ Feature: Submit Dataset
         Then a dynamo record should be created with the provided source_id
         And the dynamo record should be version 1.0
         And an automate flow started
-        And I should receive a success result with the provided source_id
+        And I should receive a success result with the generated uuid and version 1.0
 
     Scenario: Attempt to update another users record
         Given I'm authenticated with MDF
@@ -43,7 +43,7 @@ Feature: Submit Dataset
         Then a dynamo record should be created with the original source_id
         And the dynamo record should be version 1.1
         And an automate flow started
-        And I should receive a success result
+        And I should receive a success result with the generated uuid and version 1.1
 
     Scenario: Update metadata only for a submitted dataset
         Given I'm authenticated with MDF

--- a/aws/tests/test_submit.py
+++ b/aws/tests/test_submit.py
@@ -8,7 +8,7 @@ def test_publish_provided_source_id():
     pass
 
 @scenario('submit_dataset.feature', 'Submit Dataset')
-def test_publish():
+def test_submit():
     pass
 
 @scenario('submit_dataset.feature', 'Attempt to update another users record')
@@ -113,6 +113,16 @@ def no_error(submit_result, mdf_environment):
     body = json.loads(submit_result['body'])
     assert body['success']
     assert body['source_id'] == mdf_environment['source_id']
+
+
+@then(parsers.parse('I should receive a success result with the generated uuid and version {version}'))
+def no_error_with_version(submit_result, mdf_environment, version):
+    print("---------->", submit_result)
+    assert submit_result['statusCode'] == 202
+    body = json.loads(submit_result['body'])
+    assert body['success']
+    assert body['source_id'] == mdf_environment['source_id']
+    assert body['version'] == version
 
 
 @then('I should receive a failure result')


### PR DESCRIPTION
# Problem
The result from a data submission includes a version property. This is `none` for the first submission of a record, and 1.0 for the first update.

# Approach
Added test checks for this returned value and confirmed that it fails

Then saw that the *submitted* version was being returned instead of the version of the new record. Changed the source for this value and confirmed that tests are now passing.