### PR TITLE
Extract the dataset domain from the organization and set it in the mdf record

### DIFF
--- a/aws/submit_dataset.py
+++ b/aws/submit_dataset.py
@@ -236,6 +236,7 @@ def lambda_handler(event, context):
     metadata["mdf"]["versioned_source_id"] = f"{source_name}-{version}"
     metadata["mdf"]["source_name"] = source_name
     metadata["mdf"]["version"] = version
+    metadata["mdf"]["domains"] = organization.domains
 
     # Fetch custom block descriptors, cast values to str, turn _description => _desc
     # @BenB edited

--- a/aws/tests/publish.feature
+++ b/aws/tests/publish.feature
@@ -19,4 +19,5 @@ Feature: MDF Publish
         Then a dynamo record should be created
         And an automate flow started
         And the only data destinations should be globus://82f1b5c6-6e9b-11e5-ba47-22000b92c6ec/verde/
+        And the dataset's domain should be 'materials'
         And I should receive a success result

--- a/aws/tests/test_publish.py
+++ b/aws/tests/test_publish.py
@@ -20,11 +20,17 @@ def mdf_other_user_datset(mdf):
 def dyanmo_record_version(automate_record):
     assert automate_record['is_test']
 
+
 @then(parsers.parse("the only data destinations should be {destination}"))
-def dyanmo_record_version(automate_record):
+def dyanmo_record_version(destination, automate_record):
     dest_org = automate_record['organization']
     print("dest org", dest_org)
     assert len(dest_org.data_destinations) == 1
+
+
+@then(parsers.parse("the dataset's domain should be '{domain}'"))
+def check_dataset_domain(domain, automate_record):
+    assert automate_record['mdf_rec']['mdf']['domains'][0] == domain
 
 
 @given("I set the organization to VERDE", target_fixture='mdf_submission')


### PR DESCRIPTION
The organization's domain needs to be reflected in the search record as part of the MDF record.
