### PR TITLE
Keep test submissions separate from prod when testing for duplicate source IDs

### DIFF
--- a/aws/submit.py
+++ b/aws/submit.py
@@ -167,8 +167,15 @@ def lambda_handler(event, context):
 
         #
         existing_source_name = metadata.get("mdf", {}).get("source_name", None)
-        print("++++++++existing_source+++++++", existing_source_name)
+
         is_test = submission_conf["test"]
+
+        # Distinguish test sources from prod. Tack -test on the end of the provided
+        # name
+        if is_test and existing_source_name:
+            existing_source_name += "-test"
+
+        print("++++++++existing_source+++++++", existing_source_name)
 
         if not existing_source_name:
             source_name = str(uuid.uuid4())

--- a/aws/tests/submit_dataset.feature
+++ b/aws/tests/submit_dataset.feature
@@ -25,6 +25,19 @@ Feature: Submit Dataset
         And an automate flow started
         And I should receive a success result with the generated uuid and version 1.0
 
+    Scenario: Submit Test Dataset With Provided source_id
+        Given I'm authenticated with MDF
+        And I have a new MDF dataset to submit
+        And I provide the source_id
+        And I set the test flag to true
+        When I submit the dataset
+
+        Then a dynamo record should be created with the provided source_id modified to indicate test
+        And the dynamo record should be version 1.0
+        And an automate flow started
+        And I should receive a success result with test source-id, the generated uuid and version 1.0
+
+
     Scenario: Attempt to update another users record
         Given I'm authenticated with MDF
         And I have an update to another users record


### PR DESCRIPTION
# Problem
If the user specifies a source ID for their test submissions, that same ID will trigger a duplicate submission error from MDF when submitted without the test flag.

# Approach
Modify the submitted source ID by tacking `-test` on the end. That way the searches by source ID will differ between prod and test submissions.

## How I developed this
1. Added a new test to `aws/tests/submit_dataset.feature` that sets test to true and then confirms that the source ID that shows up in Dynamo has `-test` on the end.
2. This test failed
3. Updated the `submit` handler to modify the provided source ID
4. The test succeeds 

There was an existing check: _I should receive a success result with the generated uuid and version {version}_
I pulled the body out of that function and made a helper called
```python
verify_success_result(submit_result, mdf_environment, version, is_test=False)
```

I then wrote a new check: _I should receive a success result with test source-id, the generated uuid and version {version}_ which calls the helper with `is_test=True`

