### PR TITLE
 submissions separate from prod when testing for duplicate source IDs

### DIFF
--- a/aws/automate_manager.py
+++ b/aws/automate_manager.py
@@ -23,7 +23,7 @@ def authorizer_callback(*args, **kwargs):
 
 class AutomateManager:
 
-    def __init__(self, secrets: dict, is_test: bool = False):
+    def __init__(self, secrets: dict, is_test: bool):
         # Globals needed for the authorizer_callback
         global tokens, mdf_flow
 
@@ -49,10 +49,14 @@ class AutomateManager:
             self.datacite_username = secrets['DATACITE_USERNAME_PROD']
             self.datacite_password = secrets['DATACITE_PASSWORD_PROD']
             self.datacite_prefix = secrets['DATACITE_PREFIX_PROD']
+            print(f"Using PROD Datacite prefix {self.datacite_prefix}, username {self.datacite_username}")
+
         else:
             self.datacite_username = secrets['DATACITE_USERNAME_TEST']
             self.datacite_password = secrets['DATACITE_PASSWORD_TEST']
             self.datacite_prefix = secrets['DATACITE_PREFIX_TEST']
+            print(f"Using Test Datacite prefix {self.datacite_prefix}, username {self.datacite_username}")
+
 
 
         self.portal_url = os.environ.get('PORTAL_URL', None)

--- a/aws/automate_manager.py
+++ b/aws/automate_manager.py
@@ -23,7 +23,7 @@ def authorizer_callback(*args, **kwargs):
 
 class AutomateManager:
 
-    def __init__(self, secrets: dict, is_test: bool):
+    def __init__(self, secrets: dict, is_test: bool=False):
         # Globals needed for the authorizer_callback
         global tokens, mdf_flow
 

--- a/aws/submit.py
+++ b/aws/submit.py
@@ -167,8 +167,15 @@ def lambda_handler(event, context):
 
         #
         existing_source_name = metadata.get("mdf", {}).get("source_name", None)
-        print("++++++++existing_source+++++++", existing_source_name)
+
         is_test = submission_conf["test"]
+
+        # Distinguish test sources from prod. Tack -test on the end of the provided
+        # name
+        if is_test and existing_source_name:
+            existing_source_name += "-test"
+
+        print("++++++++existing_source+++++++", existing_source_name)
 
         if not existing_source_name:
             source_name = str(uuid.uuid4())

--- a/aws/submit.py
+++ b/aws/submit.py
@@ -241,6 +241,8 @@ def lambda_handler(event, context):
     metadata["mdf"]["source_name"] = source_name
     metadata["mdf"]["version"] = version
     metadata["mdf"]["domains"] = organization.domains
+    metadata["mdf"]["resource_type"] = "dataset"  # Force the resource type to make this findable in the portal
+    metadata["mdf"]["ingest_date"] = datetime.utcnow().isoformat("T") + "Z"
 
     # Fetch custom block descriptors, cast values to str, turn _description => _desc
     # @BenB edited

--- a/aws/tests/submit_dataset.feature
+++ b/aws/tests/submit_dataset.feature
@@ -25,6 +25,19 @@ Feature: Submit Dataset
         And an automate flow started
         And I should receive a success result with the generated uuid and version 1.0
 
+    Scenario: Submit Test Dataset With Provided source_id
+        Given I'm authenticated with MDF
+        And I have a new MDF dataset to submit
+        And I provide the source_id
+        And I set the test flag to true
+        When I submit the dataset
+
+        Then a dynamo record should be created with the provided source_id modified to indicate test
+        And the dynamo record should be version 1.0
+        And an automate flow started
+        And I should receive a success result with test source-id, the generated uuid and version 1.0
+
+
     Scenario: Attempt to update another users record
         Given I'm authenticated with MDF
         And I have an update to another users record

--- a/aws/tests/test_automate_manager.py
+++ b/aws/tests/test_automate_manager.py
@@ -77,7 +77,7 @@ class TestAutomateManager:
     @mock.patch('globus_automate_flow.GlobusAutomateFlow', autospec=True)
     def test_create_transfer_items(self, _, secrets, organization, set_environ):
         os.environ['PORTAL_URL'] = "https://acdc.alcf.anl.gov/mdf/detail/"
-        manager = AutomateManager(secrets)
+        manager = AutomateManager(secrets, is_test=False)
 
         data_sources = [
             "https://app.globus.org/file-manager?destination_id=e38ee745-6d04-11e5-ba46-22000b92c6ec&destination_path=%2FMDF%2Fmdf_connect%2Ftest_files%2Fcanonical_datasets%2Fdft%2F"
@@ -102,7 +102,7 @@ class TestAutomateManager:
     @mock.patch('globus_automate_flow.GlobusAutomateFlow', autospec=True)
     def test_create_transfer_items_from_origin(self, _, secrets, organization):
         os.environ['PORTAL_URL'] = "https://acdc.alcf.anl.gov/mdf/detail/"
-        manager = AutomateManager(secrets)
+        manager = AutomateManager(secrets, is_test=False)
 
         data_sources = [
             "https://app.globus.org/file-manager?origin_id=e38ee745-6d04-11e5-ba46-22000b92c6ec&origin_path=%2Fexalearn-design%2F"
@@ -127,7 +127,7 @@ class TestAutomateManager:
         os.environ['PORTAL_URL'] = "https://acdc.alcf.anl.gov/mdf/detail/"
         os.environ['GDRIVE_EP'] = "f00dfd6c-edf4-4c8b-a4b1-be6ad92a4fbb"
         os.environ['GDRIVE_ROOT'] = "/Shared With Me"
-        manager = AutomateManager(secrets)
+        manager = AutomateManager(secrets, is_test=False)
 
         data_sources = [
             "google:///mdf/my_dataset"
@@ -150,7 +150,7 @@ class TestAutomateManager:
     @mock.patch('globus_automate_flow.GlobusAutomateFlow', autospec=True)
     def test_create_transfer_items_test_submit(self, _, secrets, organization, set_environ):
         os.environ['PORTAL_URL'] = "https://acdc.alcf.anl.gov/mdf/detail/"
-        manager = AutomateManager(secrets)
+        manager = AutomateManager(secrets, is_test=True)
 
         data_sources = [
             "https://app.globus.org/file-manager?destination_id=e38ee745-6d04-11e5-ba46-22000b92c6ec&destination_path=%2FMDF%2Fmdf_connect%2Ftest_files%2Fcanonical_datasets%2Fdft%2F"
@@ -176,7 +176,7 @@ class TestAutomateManager:
         mock_flow = mocker.Mock()
         mock_automate.from_existing_flow = mocker.Mock(return_value=mock_flow)
         os.environ['PORTAL_URL'] = "https://acdc.alcf.anl.gov/mdf/detail/"
-        manager = AutomateManager(secrets)
+        manager = AutomateManager(secrets, is_test=False)
 
         data_sources = [
             "https://app.globus.org/file-manager?destination_id=e38ee745-6d04-11e5-ba46-22000b92c6ec&destination_path=%2FMDF%2Fmdf_connect%2Ftest_files%2Fcanonical_datasets%2Fdft%2F"
@@ -200,7 +200,15 @@ class TestAutomateManager:
         mock_flow = mocker.Mock()
         mock_automate.from_existing_flow = mocker.Mock(return_value=mock_flow)
         os.environ['PORTAL_URL'] = "https://acdc.alcf.anl.gov/mdf/detail/"
-        manager = AutomateManager(secrets)
+        manager = AutomateManager(secrets, is_test=False)
+        assert manager.datacite_username == "datacite_prod_usrname_1234"
+        assert manager.datacite_password == "datacite_prod_passwrd_1234"
+        assert manager.datacite_prefix == "10.12345"
+
+        manager = AutomateManager(secrets, is_test=True)
+        assert manager.datacite_username == "datacite_test_usrname_1234"
+        assert manager.datacite_password == "datacite_test_passwrd_1234"
+        assert manager.datacite_prefix == "10.12347"
 
         data_sources = [
             "https://app.globus.org/file-manager?destination_id=e38ee745-6d04-11e5-ba46-22000b92c6ec&destination_path=%2FMDF%2Fmdf_connect%2Ftest_files%2Fcanonical_datasets%2Fdft%2F"


### PR DESCRIPTION
# Problem
If the user specifies a source ID for their test submissions, that same ID will trigger a duplicate submission error from MDF when submitted without the test flag.

# Approach
Modify the submitted source ID by tacking `-test` on the end. That way the searches by source ID will differ between prod and test submissions.

## How I developed this
1. Added a new test to `aws/tests/submit_dataset.feature` that sets test to true and then confirms that the source ID that shows up in Dynamo has `-test` on the end.
2. This test failed
3. Updated the `submit` handler to modify the provided source ID
4. The test succeeds 

There was an existing check: _I should receive a success result with the generated uuid and version {version}_
I pulled the body out of that function and made a helper called
```python
verify_success_result(submit_result, mdf_environment, version, is_test=False)
```

I then wrote a new check: _I should receive a success result with test source-id, the generated uuid and version {version}_ which calls the helper with `is_test=True`

