### PR TITLE
Make dyanamo table read capacity a variable

### DIFF
--- a/infra/mdf/dev/main.tf
+++ b/infra/mdf/dev/main.tf
@@ -47,6 +47,7 @@ module "dynamodb" {
   env_vars  = var.env_vars
   resource_tags             = var.resource_tags
   dynamodb_write_capacity = 20
+  dynamodb_read_capacity    = 20
 }
 
 module "permissions" {

--- a/infra/mdf/modules/dynamo/main.tf
+++ b/infra/mdf/modules/dynamo/main.tf
@@ -2,7 +2,7 @@
 resource "aws_dynamodb_table" "dynamodb-table" {
   name           = "${var.namespace}-${var.env}"
   billing_mode   = "PROVISIONED"
-  read_capacity  = 5
+  read_capacity  = var.dynamodb_read_capacity
   write_capacity = var.dynamodb_write_capacity
   hash_key       = "source_id"
   range_key      = "version"

--- a/infra/mdf/modules/dynamo/variables.tf
+++ b/infra/mdf/modules/dynamo/variables.tf
@@ -22,3 +22,8 @@ variable "dynamodb_write_capacity" {
   type = number
   description = "The write capacity for the DynamoDB table."
 }
+
+variable "dynamodb_read_capacity" {
+  type = number
+  description = "The read capacity for the DynamoDB table."
+}

--- a/infra/mdf/prod/main.tf
+++ b/infra/mdf/prod/main.tf
@@ -46,6 +46,7 @@ module "dynamodb" {
   env_vars  = var.env_vars
   resource_tags             = var.resource_tags
   dynamodb_write_capacity   = 20
+  dynamodb_read_capacity    = 20
 }
 
 module "permissions" {


### PR DESCRIPTION
# Problem
With heavy use, the `submissions` endpoint is failing with a capacity exception:
```
[ERROR] ProvisionedThroughputExceededException: An error occurred (ProvisionedThroughputExceededException) when calling the Scan operation (reached max retries: 9): The level of configured provisioned throughput for the table was exceeded. Consider increasing your provisioning level with the UpdateTable API.
```

# Approach
Make this a variable and update it from five to twenty
