### PR TITLE
datacite minting fixes (#112)

### DIFF
--- a/automate/minimus_mdf_flow.py
+++ b/automate/minimus_mdf_flow.py
@@ -334,6 +334,10 @@ def mint_doi_steps():
                         "publisher.$": "$.dataset_mdata.dc.publisher",
                         "publicationYear.$": "$.dataset_mdata.dc.publicationYear",
                         "url.$": "$.mdf_portal_link",
+                        "event": "publish",
+                        "types": {
+                            "resourceTypeGeneral": "Dataset"
+                        }
                     },
                 },
                 "__Private_Parameters": ["username", "password"],


### PR DESCRIPTION
# Problem
Unless we set the DataCite `event` property to _publish_,  and the `resourceTypeGeneral` to _general_ the entry will remain in a draft state.

# Approach
Set these values in the DataCite AP parameters

