### PR TITLE
Update BDD test to clarify what happens to the search record on an update

### DIFF
--- a/aws/tests/submit_dataset.feature
+++ b/aws/tests/submit_dataset.feature
@@ -11,7 +11,7 @@ Feature: Submit Dataset
         And the previous_versions field should be empty
         And an automate flow started
         And the data destination should be the Petrel MDF directory
-        And the search subject should be the uuid with the version
+        And a new search record is inserted where the subject is the uuid with the version 1.0
         And I should receive a success result with the generated uuid and version 1.0
 
     Scenario: Submit Dataset With Provided source_id
@@ -66,6 +66,7 @@ Feature: Submit Dataset
         And the dynamo record should be version 1.1
         And the previous_versions field should be ['my dataset-1.0']
         And an automate flow started
+        And a new search record is inserted where the subject is the uuid with the version 1.1
         And I should receive a success result with the generated uuid and version 1.1
 
     Scenario: Update metadata only for a submitted dataset

--- a/aws/tests/test_submit.py
+++ b/aws/tests/test_submit.py
@@ -205,10 +205,10 @@ def dyanmo_record_version(version_num, dynamo_record):
 def check_data_dest(automate_record):
     print("Autaomte", automate_record)
 
-@then("the search subject should be the uuid with the version")
-def check_search_index_subject(automate_record):
-    assert automate_record["mdf_rec"]["mdf"]["version"] == '1.0'
-    assert automate_record["mdf_rec"]["mdf"]['versioned_source_id'] == automate_record["mdf_rec"]["mdf"]["source_id"]+"-1.0"
+@then(parsers.parse("a new search record is inserted where the subject is the uuid with the version {version}"))
+def check_search_index_subject(automate_record, version):
+    assert automate_record["mdf_rec"]["mdf"]["version"] == version
+    assert automate_record["mdf_rec"]["mdf"]['versioned_source_id'] == automate_record["mdf_rec"]["mdf"]["source_id"]+"-"+version
 
 @then('an automate flow started that skips the file transfer', target_fixture="automate_record")
 def check_skip_file_transfer(mdf_environment):


### PR DESCRIPTION
# Problem
It's not clear from the BDD tests what happens with the search record when an update is submitted

# Approach
Make the test statement explicit that it adding a new search record. Parameterize the test statement to allow version to be specified in the test.

