### PR TITLE
Fix set_permission rename

### DIFF
--- a/automate/minimus_mdf_flow.py
+++ b/automate/minimus_mdf_flow.py
@@ -114,7 +114,7 @@ def file_transfer_steps():
         "UserPermissions": {
             "Comment": "Temporarily add write permissions for the submitting user",
             "Type": "Action",
-            "ActionUrl": "https://transfer.actions.globus.org/set_permission",
+            "ActionUrl": "https://transfer.actions.globus.org/manage_permission",
             "ExceptionOnActionFailure": False,
             "Parameters": {
                 "operation": "CREATE",


### PR DESCRIPTION
Handle this case:
> An exception to this is the "set_permission" action provider, which has been renamed to "manage_permission". States using the https://actions.globus.org/transfer/set_permission ActionUrl should be changed to https://transfer.actions.globus.org/manage_permission.

